### PR TITLE
Fix invalid default Codex model

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -78,4 +78,4 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .factory/tmp/prompt.md
           sandbox: workspace-write
-          model: ${{ vars.FACTORY_CODEX_MODEL || 'codex-mini-latest' }}
+          model: ${{ vars.FACTORY_CODEX_MODEL || 'gpt-5-codex' }}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Configure these before using the scaffold in a live repository:
    `.github/workflows/factory-pr-loop.yml`.
 4. Protect your default branch and require normal human review for merges.
 5. Run the `Factory Bootstrap` workflow once to create the required labels.
+6. Optional: set the `FACTORY_CODEX_MODEL` Actions variable if you want to
+   override the default `gpt-5-codex` model used by the stage runner.
 
 ## Factory operator flow
 


### PR DESCRIPTION
## Summary
- replace the invalid `codex-mini-latest` default with `gpt-5-codex` in the shared stage runner
- document the optional `FACTORY_CODEX_MODEL` Actions variable override in the README

## Why
The factory workflows were failing in `openai/codex-action@v1` with `model_not_found` because the current default model name no longer exists.

## Validation
- npm test