### PR TITLE
Checkout repo before running factory scripts

### DIFF
--- a/.github/workflows/factory-intake.yml
+++ b/.github/workflows/factory-intake.yml
@@ -61,6 +61,9 @@ jobs:
       - plan
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/factory-pr-loop.yml
+++ b/.github/workflows/factory-pr-loop.yml
@@ -33,6 +33,9 @@ jobs:
       repeated_failure_count: ${{ steps.route.outputs.repeated_failure_count }}
       last_failure_signature: ${{ steps.route.outputs.last_failure_signature }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -49,6 +52,9 @@ jobs:
     needs: route
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -88,6 +94,9 @@ jobs:
     needs: route
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -110,6 +119,9 @@ jobs:
     needs: route
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- add checkout steps to factory jobs that execute repository scripts outside the reusable stage runner
- fix the PR loop route job and intake finalize job so they can actually load files from `scripts/`

## Why
Several workflow jobs were calling `node scripts/...` without first checking out the repository. On GitHub runners that fails with `MODULE_NOT_FOUND`, which is why `Factory PR Loop` was crashing on every `workflow_run` event and `Factory Intake` would have failed in `finalize` after planning.

## Validation
- npm test