### PR TITLE
Run Codex in full-auto mode

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -79,3 +79,4 @@ jobs:
           prompt-file: .factory/tmp/prompt.md
           sandbox: workspace-write
           model: ${{ vars.FACTORY_CODEX_MODEL || 'gpt-5-codex' }}
+          codex-args: --full-auto

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Configure these before using the scaffold in a live repository:
 5. Run the `Factory Bootstrap` workflow once to create the required labels.
 6. Optional: set the `FACTORY_CODEX_MODEL` Actions variable if you want to
    override the default `gpt-5-codex` model used by the stage runner.
+7. The stage runner executes Codex with `--full-auto` so planning, coding, and
+   repair runs stay non-interactive inside GitHub Actions.
 
 ## Factory operator flow
 


### PR DESCRIPTION
## Summary
- pass `--full-auto` to `openai/codex-action` in the shared stage runner
- document that the factory executes Codex non-interactively in Actions

## Why
The current intake run is stuck in the `Run Codex` step. The factory is meant to be autonomous, and the official action exposes `codex-args` for this kind of execution control. Using `--full-auto` makes the planning, implementation, and repair stages explicitly non-interactive.

## Validation
- npm test