### PR TITLE
Persist Codex stage output

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -79,3 +79,16 @@ jobs:
           prompt-file: .factory/tmp/prompt.md
           sandbox: workspace-write
           model: ${{ vars.FACTORY_CODEX_MODEL || 'gpt-5-codex' }}
+          codex-args: --full-auto
+
+      - name: Commit and push stage output
+        run: |
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "Codex completed without producing repository changes."
+            exit 1
+          fi
+
+          git commit -m "factory(${{ inputs.mode }}): issue #${{ inputs.issue_number }}"
+          git push origin "HEAD:${{ inputs.branch }}"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Configure these before using the scaffold in a live repository:
 5. Run the `Factory Bootstrap` workflow once to create the required labels.
 6. Optional: set the `FACTORY_CODEX_MODEL` Actions variable if you want to
    override the default `gpt-5-codex` model used by the stage runner.
+7. The stage runner executes Codex with `--full-auto` so planning, coding, and
+   repair runs stay non-interactive inside GitHub Actions.
 
 ## Factory operator flow
 


### PR DESCRIPTION
## Summary
- run Codex with `--full-auto` in the shared stage runner
- commit and push stage output back to the factory branch after each plan/implement/repair run
- fail the stage if Codex produces no repository changes

## Why
The latest intake run proved that planning can now complete, but `finalize` still failed with `No commits between main and factory/...`. The stage runner was never persisting Codex edits, so the factory branch remained identical to `main`.

## Validation
- npm test