### PR TITLE
Push Codex-authored commits

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -85,10 +85,16 @@ jobs:
         run: |
           git add -A
 
-          if git diff --cached --quiet; then
+          if ! git diff --cached --quiet; then
+            git commit -m "factory(${{ inputs.mode }}): issue #${{ inputs.issue_number }}"
+          fi
+
+          local_head="$(git rev-parse HEAD)"
+          remote_head="$(git rev-parse origin/${{ inputs.branch }} 2>/dev/null || true)"
+
+          if [ "$local_head" = "$remote_head" ]; then
             echo "Codex completed without producing repository changes."
             exit 1
           fi
 
-          git commit -m "factory(${{ inputs.mode }}): issue #${{ inputs.issue_number }}"
           git push origin "HEAD:${{ inputs.branch }}"


### PR DESCRIPTION
## Summary
- make the stage runner treat a local commit ahead of origin as valid Codex output
- only create a new commit when staged changes still exist after Codex returns

## Why
The latest intake run reached the persistence step, but Codex had already committed the planning artifacts inside the sandbox. Our follow-up step only looked for staged changes, so it falsely concluded there was no output and exited before pushing the local commit back to the factory branch.

## Validation
- npm test