### PR TITLE
Trim factory stage prompts

### DIFF
--- a/.factory/prompts/implement.md
+++ b/.factory/prompts/implement.md
@@ -2,6 +2,8 @@ You are the implementation stage of a GitHub-native autonomous software factory.
 
 Work only on the current branch and stay within the approved plan. Use the
 artifacts already committed in the repository as the source of truth.
+The context below is intentionally compact. Read the referenced repo files for
+full detail instead of relying on inline copies.
 
 Implementation rules:
 

--- a/.factory/prompts/plan.md
+++ b/.factory/prompts/plan.md
@@ -2,6 +2,8 @@ You are the planning stage of a GitHub-native autonomous software factory.
 
 Work only on the current branch. Your job is to refine the request into
 planning artifacts. Do not implement product code in this stage.
+The context below is intentionally trimmed. Use the referenced repository files
+directly if you need more detail from prior artifacts.
 
 Required outputs:
 

--- a/.factory/prompts/repair.md
+++ b/.factory/prompts/repair.md
@@ -2,6 +2,8 @@ You are the repair stage of a GitHub-native autonomous software factory.
 
 Work only on the current branch. Your job is to address the already-reported
 failure context and nothing else.
+The context below is intentionally compact. Read the referenced repo files for
+full detail instead of relying on inline copies.
 
 Repair rules:
 

--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -71,6 +71,10 @@ jobs:
           FACTORY_MAX_REPAIR_ATTEMPTS: ${{ inputs.max_repair_attempts }}
           FACTORY_CI_RUN_ID: ${{ inputs.ci_run_id }}
           FACTORY_REVIEW_ID: ${{ inputs.review_id }}
+          FACTORY_PLAN_PROMPT_MAX_CHARS: ${{ vars.FACTORY_PLAN_PROMPT_MAX_CHARS || '' }}
+          FACTORY_IMPLEMENT_PROMPT_MAX_CHARS: ${{ vars.FACTORY_IMPLEMENT_PROMPT_MAX_CHARS || '' }}
+          FACTORY_REPAIR_PROMPT_MAX_CHARS: ${{ vars.FACTORY_REPAIR_PROMPT_MAX_CHARS || '' }}
+          FACTORY_PROMPT_HARD_MAX_CHARS: ${{ vars.FACTORY_PROMPT_HARD_MAX_CHARS || '' }}
 
       - name: Run Codex
         uses: openai/codex-action@v1

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Configure these before using the scaffold in a live repository:
    override the default `gpt-5-codex` model used by the stage runner.
 7. The stage runner executes Codex with `--full-auto` so planning, coding, and
    repair runs stay non-interactive inside GitHub Actions.
+8. Optional: tune prompt budgets with the following Actions variables:
+   `FACTORY_PLAN_PROMPT_MAX_CHARS`, `FACTORY_IMPLEMENT_PROMPT_MAX_CHARS`,
+   `FACTORY_REPAIR_PROMPT_MAX_CHARS`, and `FACTORY_PROMPT_HARD_MAX_CHARS`.
 
 ## Factory operator flow
 

--- a/scripts/build-stage-prompt.mjs
+++ b/scripts/build-stage-prompt.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseIssueForm } from "./lib/issue-form.mjs";
 import { extractPrMetadata } from "./lib/pr-metadata.mjs";
 import {
@@ -10,6 +11,122 @@ import {
   listWorkflowRunJobs
 } from "./lib/github.mjs";
 
+export const DEFAULT_PROMPT_BUDGETS = Object.freeze({
+  plan: 20000,
+  implement: 12000,
+  repair: 14000,
+  hardMax: 24000
+});
+
+const ARTIFACT_FILES = [
+  "spec.md",
+  "plan.md",
+  "acceptance-tests.md",
+  "repair-log.md"
+];
+
+const ISSUE_SECTION_CONFIG = [
+  { key: "problemStatement", title: "Problem Statement", priority: 6 },
+  { key: "goals", title: "Goals", priority: 5 },
+  { key: "acceptanceCriteria", title: "Acceptance Criteria", priority: 4 },
+  { key: "constraints", title: "Constraints", priority: 3 },
+  { key: "risk", title: "Risk", priority: 2 },
+  { key: "affectedArea", title: "Affected Area", priority: 1 },
+  { key: "nonGoals", title: "Non-Goals", priority: 0 }
+];
+
+const STAGE_SECTION_CONFIG = {
+  plan: {
+    order: ["run-metadata", "problem", "goals", "acceptance", "constraints", "risk", "affected-area", "non-goals", "artifacts"],
+    preferredChars: {
+      "run-metadata": 500,
+      problem: 3500,
+      goals: 2500,
+      acceptance: 2500,
+      constraints: 1800,
+      risk: 1200,
+      "affected-area": 400,
+      "non-goals": 1000,
+      artifacts: 1500
+    },
+    minChars: {
+      "run-metadata": 200,
+      problem: 500,
+      goals: 300,
+      acceptance: 300,
+      constraints: 200,
+      risk: 120,
+      "affected-area": 0,
+      "non-goals": 0,
+      artifacts: 0
+    },
+    dropPriority: ["non-goals", "affected-area", "risk", "constraints", "artifacts", "acceptance", "goals", "problem"]
+  },
+  implement: {
+    order: ["run-metadata", "issue-synopsis", "artifact-index"],
+    preferredChars: {
+      "run-metadata": 500,
+      "issue-synopsis": 1200,
+      "artifact-index": 5000
+    },
+    minChars: {
+      "run-metadata": 200,
+      "issue-synopsis": 200,
+      "artifact-index": 800
+    },
+    dropPriority: ["issue-synopsis", "artifact-index"]
+  },
+  repair: {
+    order: ["run-metadata", "failure-context", "artifact-index", "repair-log-tail", "issue-synopsis"],
+    preferredChars: {
+      "run-metadata": 500,
+      "failure-context": 5000,
+      "artifact-index": 3500,
+      "repair-log-tail": 1200,
+      "issue-synopsis": 800
+    },
+    minChars: {
+      "run-metadata": 200,
+      "failure-context": 800,
+      "artifact-index": 600,
+      "repair-log-tail": 0,
+      "issue-synopsis": 120
+    },
+    dropPriority: ["issue-synopsis", "repair-log-tail", "artifact-index", "failure-context"]
+  }
+};
+
+function positiveInt(input, fallback) {
+  const parsed = Number(input);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolvePromptBudgets(env = process.env) {
+  const hardMax = positiveInt(
+    env.FACTORY_PROMPT_HARD_MAX_CHARS,
+    DEFAULT_PROMPT_BUDGETS.hardMax
+  );
+
+  return {
+    hardMax,
+    plan: Math.min(
+      positiveInt(env.FACTORY_PLAN_PROMPT_MAX_CHARS, DEFAULT_PROMPT_BUDGETS.plan),
+      hardMax
+    ),
+    implement: Math.min(
+      positiveInt(
+        env.FACTORY_IMPLEMENT_PROMPT_MAX_CHARS,
+        DEFAULT_PROMPT_BUDGETS.implement
+      ),
+      hardMax
+    ),
+    repair: Math.min(
+      positiveInt(env.FACTORY_REPAIR_PROMPT_MAX_CHARS, DEFAULT_PROMPT_BUDGETS.repair),
+      hardMax
+    )
+  };
+}
+
 function maybeRead(filePath) {
   try {
     return fs.readFileSync(filePath, "utf8").trim();
@@ -18,151 +135,599 @@ function maybeRead(filePath) {
   }
 }
 
-function truncate(text, length = 6000) {
+function truncateText(text, maxChars) {
   const value = `${text || ""}`.trim();
-  return value.length > length ? `${value.slice(0, length)}\n...[truncated]` : value;
-}
 
-function section(title, body) {
-  return body ? `## ${title}\n${body.trim()}\n` : "";
-}
-
-function renderIssueSections(parsedIssue) {
-  return [
-    section("Problem Statement", parsedIssue.problemStatement),
-    section("Goals", parsedIssue.goals),
-    section("Non-Goals", parsedIssue.nonGoals),
-    section("Constraints", parsedIssue.constraints),
-    section("Acceptance Criteria", parsedIssue.acceptanceCriteria),
-    section("Risk", parsedIssue.risk),
-    section("Affected Area", parsedIssue.affectedArea)
-  ].join("\n");
-}
-
-function renderArtifacts(artifactsPath) {
-  const files = [
-    "spec.md",
-    "plan.md",
-    "acceptance-tests.md",
-    "repair-log.md"
-  ];
-
-  return files
-    .map((fileName) => {
-      const fullPath = path.join(artifactsPath, fileName);
-      const contents = maybeRead(fullPath);
-      return [
-        `### ${fileName}`,
-        "",
-        contents ? "```md\n" + truncate(contents) + "\n```" : "_Not present yet_",
-        ""
-      ].join("\n");
-    })
-    .join("\n");
-}
-
-function renderJobsSummary(jobsPayload) {
-  const jobs = jobsPayload?.jobs || [];
-
-  if (!jobs.length) {
+  if (!value || maxChars <= 0) {
     return "";
   }
 
-  return jobs
-    .map((job) => {
-      const failedSteps = (job.steps || [])
-        .filter((step) => step.conclusion && step.conclusion !== "success")
-        .map((step) => `  - ${step.name}: ${step.conclusion}`);
+  if (value.length <= maxChars) {
+    return value;
+  }
 
-      return [
-        `- ${job.name}: ${job.conclusion}`,
-        ...failedSteps
-      ].join("\n");
+  if (maxChars <= 16) {
+    return value.slice(0, maxChars);
+  }
+
+  return `${value.slice(0, maxChars - 16).trimEnd()}\n...[truncated]`;
+}
+
+function tailText(text, maxChars) {
+  const value = `${text || ""}`.trim();
+
+  if (!value || value.length <= maxChars) {
+    return value;
+  }
+
+  if (maxChars <= 18) {
+    return value.slice(-maxChars);
+  }
+
+  return `...[tail]\n${value.slice(-(maxChars - 10)).trimStart()}`;
+}
+
+function compactLines(text, maxLines = 4, maxChars = 400) {
+  const lines = `${text || ""}`
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, maxLines);
+
+  return truncateText(lines.join("\n"), maxChars);
+}
+
+function firstParagraph(text, maxChars = 260) {
+  const paragraphs = `${text || ""}`
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+
+  return truncateText(paragraphs[0] || "", maxChars);
+}
+
+function extractMarkdownHeadings(text, maxHeadings = 8) {
+  const headings = [];
+
+  for (const line of `${text || ""}`.split("\n")) {
+    const match = line.match(/^#{1,6}\s+(.*)$/);
+
+    if (!match) {
+      continue;
+    }
+
+    headings.push(match[1].trim());
+
+    if (headings.length >= maxHeadings) {
+      break;
+    }
+  }
+
+  return headings;
+}
+
+function renderSection(title, body) {
+  return body ? `## ${title}\n${body.trim()}\n` : "";
+}
+
+function serializeSection(section) {
+  return renderSection(section.title, section.body);
+}
+
+function describeIssueSynopsis(parsedIssue) {
+  const parts = [];
+
+  if (parsedIssue.problemStatement) {
+    parts.push(`Problem: ${firstParagraph(parsedIssue.problemStatement, 260)}`);
+  }
+
+  if (parsedIssue.goals) {
+    parts.push(`Goals:\n${compactLines(parsedIssue.goals, 4, 320)}`);
+  }
+
+  if (parsedIssue.acceptanceCriteria) {
+    parts.push(
+      `Acceptance:\n${compactLines(parsedIssue.acceptanceCriteria, 4, 320)}`
+    );
+  }
+
+  if (parsedIssue.constraints) {
+    parts.push(`Constraints:\n${compactLines(parsedIssue.constraints, 3, 220)}`);
+  }
+
+  return parts.join("\n\n");
+}
+
+function summarizeArtifact(fileName, artifactsPath) {
+  const filePath = path.join(artifactsPath, fileName);
+  const contents = maybeRead(filePath);
+  const headings = extractMarkdownHeadings(contents);
+  const summary = headings.length
+    ? `headings: ${headings.join(" | ")}`
+    : firstParagraph(contents, 220);
+
+  return {
+    id: fileName,
+    fileName,
+    filePath,
+    exists: Boolean(contents),
+    headings,
+    summary
+  };
+}
+
+function renderPlanArtifactsSection(artifactsPath) {
+  const lines = ARTIFACT_FILES.map((fileName) => {
+    const contents = maybeRead(path.join(artifactsPath, fileName));
+    return `- ${fileName}: ${contents ? "present" : "missing"}`;
+  });
+
+  const repairLog = maybeRead(path.join(artifactsPath, "repair-log.md"));
+
+  if (repairLog) {
+    lines.push("");
+    lines.push("repair-log tail:");
+    lines.push(tailText(repairLog, 700));
+  }
+
+  return lines.join("\n").trim();
+}
+
+function renderArtifactIndex(artifactsPath) {
+  return ARTIFACT_FILES
+    .filter((fileName) => fileName !== "repair-log.md")
+    .map((fileName) => {
+      const artifact = summarizeArtifact(fileName, artifactsPath);
+      const parts = [
+        `- ${artifact.fileName}: ${artifact.exists ? "present" : "missing"} at \`${artifact.filePath}\``
+      ];
+
+      if (artifact.exists && artifact.summary) {
+        parts.push(`  ${artifact.summary}`);
+      }
+
+      return parts.join("\n");
     })
     .join("\n");
 }
 
-const mode = process.env.FACTORY_MODE;
-const issueNumber = Number(process.env.FACTORY_ISSUE_NUMBER);
-const prNumber = Number(process.env.FACTORY_PR_NUMBER);
-const branch = process.env.FACTORY_BRANCH;
-const artifactsPath = process.env.FACTORY_ARTIFACTS_PATH;
-const reviewId = process.env.FACTORY_REVIEW_ID;
-const ciRunId = process.env.FACTORY_CI_RUN_ID;
+function renderRunMetadata({
+  mode,
+  issueNumber,
+  prNumber,
+  branch,
+  metadata
+}) {
+  return [
+    `- Mode: ${mode}`,
+    `- Issue: #${issueNumber}`,
+    `- Pull Request: ${prNumber > 0 ? `#${prNumber}` : "not created yet"}`,
+    `- Branch: ${branch}`,
+    `- Current status: ${metadata.status || "unknown"}`
+  ].join("\n");
+}
 
-const issue = await getIssue(issueNumber);
-const parsedIssue = parseIssueForm(issue.body);
-const pullRequest =
-  prNumber > 0 && mode !== "plan" ? await getPullRequest(prNumber) : null;
-const metadata = pullRequest ? extractPrMetadata(pullRequest.body) || {} : {};
-const review =
-  pullRequest && reviewId && mode === "repair"
-    ? await getReview(prNumber, reviewId)
-    : null;
-const reviewComments =
-  pullRequest && reviewId && mode === "repair"
-    ? await listReviewComments(prNumber, reviewId)
-    : [];
-const jobsPayload =
-  pullRequest && ciRunId && mode === "repair"
-    ? await listWorkflowRunJobs(ciRunId)
-    : null;
+function renderFailureContext({
+  mode,
+  ciRunId,
+  jobsPayload,
+  review,
+  reviewComments
+}) {
+  if (mode !== "repair") {
+    return "";
+  }
 
-const context = [
-  section(
-    "Run Metadata",
-    [
-      `- Mode: ${mode}`,
-      `- Issue: #${issueNumber}`,
-      `- Pull Request: ${pullRequest ? `#${prNumber}` : "not created yet"}`,
-      `- Branch: ${pullRequest ? pullRequest.head.ref : branch}`,
-      `- Current status: ${metadata.status || "unknown"}`
-    ].join("\n")
-  ),
-  section("Issue Request", renderIssueSections(parsedIssue)),
-  pullRequest
-    ? section(
-        "Pull Request Summary",
-        truncate(
-          pullRequest.body.replace(/<!--\s*factory-state[\s\S]*?-->/m, "").trim()
-        )
+  if (jobsPayload?.jobs?.length) {
+    const lines = [`- Workflow run id: ${ciRunId}`];
+    const failedJobs = jobsPayload.jobs.filter(
+      (job) => job.conclusion && job.conclusion !== "success"
+    );
+
+    for (const job of failedJobs) {
+      lines.push(`- ${job.name}: ${job.conclusion}`);
+
+      for (const step of (job.steps || []).filter(
+        (item) => item.conclusion && item.conclusion !== "success"
+      )) {
+        lines.push(`  - ${step.name}: ${step.conclusion}`);
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  if (review) {
+    const lines = [
+      `- Review state: ${review.state}`,
+      `- Review body: ${truncateText(review.body || "(empty)", 1800)}`
+    ];
+
+    if (reviewComments.length) {
+      lines.push("");
+      lines.push("Review comments:");
+
+      for (const comment of reviewComments.slice(0, 8)) {
+        lines.push(
+          `- ${comment.path || "general"}: ${truncateText(comment.body || "", 220)}`
+        );
+      }
+    }
+
+    return lines.join("\n");
+  }
+
+  return "";
+}
+
+function buildSection(id, title, body) {
+  return {
+    id,
+    title,
+    body: `${body || ""}`.trim(),
+    originalChars: `${body || ""}`.trim().length,
+    included: Boolean(`${body || ""}`.trim()),
+    truncated: false,
+    dropped: false
+  };
+}
+
+function applyPreferredCaps(sections, modeConfig) {
+  for (const section of sections) {
+    const preferred = modeConfig.preferredChars[section.id];
+
+    if (!preferred || !section.body) {
+      continue;
+    }
+
+    if (section.body.length > preferred) {
+      section.body = truncateText(section.body, preferred);
+      section.truncated = true;
+    }
+  }
+}
+
+function fitSectionsToBudget(sections, modeConfig, budget) {
+  const byId = new Map(sections.map((section) => [section.id, section]));
+
+  function totalChars() {
+    return sections
+      .filter((section) => section.included && section.body)
+      .map((section) => serializeSection(section).length)
+      .reduce((sum, value) => sum + value, 0);
+  }
+
+  let total = totalChars();
+
+  for (const id of modeConfig.dropPriority) {
+    if (total <= budget) {
+      break;
+    }
+
+    const section = byId.get(id);
+
+    if (!section || !section.included || !section.body) {
+      continue;
+    }
+
+    const minChars = modeConfig.minChars[id] ?? 0;
+
+    if (section.body.length > minChars) {
+      const reductionNeeded = total - budget;
+      const nextLength = Math.max(minChars, section.body.length - reductionNeeded);
+
+      if (nextLength < section.body.length) {
+        section.body = truncateText(section.body, nextLength);
+        section.truncated = true;
+        total = totalChars();
+      }
+    }
+
+    if (total <= budget) {
+      break;
+    }
+
+    if (minChars === 0 && section.body) {
+      section.body = "";
+      section.included = false;
+      section.dropped = true;
+      total = totalChars();
+    }
+  }
+
+  return total;
+}
+
+function buildSectionsForMode({
+  mode,
+  issueNumber,
+  prNumber,
+  branch,
+  artifactsPath,
+  parsedIssue,
+  metadata,
+  review,
+  reviewComments,
+  jobsPayload,
+  ciRunId
+}) {
+  const sections = [];
+
+  sections.push(
+    buildSection(
+      "run-metadata",
+      "Run Metadata",
+      renderRunMetadata({ mode, issueNumber, prNumber, branch, metadata })
+    )
+  );
+
+  if (mode === "plan") {
+    const byKey = Object.fromEntries(
+      ISSUE_SECTION_CONFIG.map((entry) => [entry.key, entry])
+    );
+
+    sections.push(
+      buildSection(
+        "problem",
+        byKey.problemStatement.title,
+        parsedIssue.problemStatement
+      ),
+      buildSection("goals", byKey.goals.title, parsedIssue.goals),
+      buildSection(
+        "acceptance",
+        byKey.acceptanceCriteria.title,
+        parsedIssue.acceptanceCriteria
+      ),
+      buildSection(
+        "constraints",
+        byKey.constraints.title,
+        parsedIssue.constraints
+      ),
+      buildSection("risk", byKey.risk.title, parsedIssue.risk),
+      buildSection(
+        "affected-area",
+        byKey.affectedArea.title,
+        parsedIssue.affectedArea
+      ),
+      buildSection("non-goals", byKey.nonGoals.title, parsedIssue.nonGoals),
+      buildSection(
+        "artifacts",
+        "Artifact Status",
+        renderPlanArtifactsSection(artifactsPath)
       )
-    : "",
-  section("Existing Artifacts", renderArtifacts(artifactsPath)),
-  review
-    ? section(
-        "Review Feedback",
-        [
-          `- Review state: ${review.state}`,
-          `- Review body: ${review.body || "(empty)"}`,
-          "",
-          "### Review comments",
-          reviewComments.length
-            ? reviewComments
-                .map((comment) => `- ${comment.path || "general"}: ${comment.body}`)
-                .join("\n")
-            : "- No line comments attached to the review"
-        ].join("\n")
-      )
-    : "",
-  jobsPayload
-    ? section(
-        "CI Failure Context",
-        [
-          `- Workflow run id: ${ciRunId}`,
-          "",
-          renderJobsSummary(jobsPayload)
-        ].join("\n")
-      )
-    : ""
-].filter(Boolean).join("\n");
+    );
+  }
 
-const templatePath = path.join(".factory", "prompts", `${mode}.md`);
-const template = fs.readFileSync(templatePath, "utf8");
-const prompt = template
-  .replaceAll("{{ISSUE_NUMBER}}", String(issueNumber))
-  .replaceAll("{{ARTIFACTS_PATH}}", artifactsPath)
-  .replace("{{CONTEXT}}", context);
+  if (mode === "implement") {
+    sections.push(
+      buildSection(
+        "issue-synopsis",
+        "Issue Synopsis",
+        describeIssueSynopsis(parsedIssue)
+      ),
+      buildSection(
+        "artifact-index",
+        "Artifact Index",
+        renderArtifactIndex(artifactsPath)
+      )
+    );
+  }
 
-fs.mkdirSync(path.join(".factory", "tmp"), { recursive: true });
-fs.writeFileSync(path.join(".factory", "tmp", "prompt.md"), prompt);
+  if (mode === "repair") {
+    const repairLog = maybeRead(path.join(artifactsPath, "repair-log.md"));
+
+    sections.push(
+      buildSection(
+        "failure-context",
+        "Failure Context",
+        renderFailureContext({
+          mode,
+          ciRunId,
+          jobsPayload,
+          review,
+          reviewComments
+        })
+      ),
+      buildSection(
+        "artifact-index",
+        "Artifact Index",
+        renderArtifactIndex(artifactsPath)
+      ),
+      buildSection(
+        "repair-log-tail",
+        "Repair Log Tail",
+        tailText(repairLog, 1000)
+      ),
+      buildSection(
+        "issue-synopsis",
+        "Issue Synopsis",
+        describeIssueSynopsis(parsedIssue)
+      )
+    );
+  }
+
+  return sections;
+}
+
+export function buildStagePrompt({
+  mode,
+  issueNumber,
+  prNumber = 0,
+  branch,
+  artifactsPath,
+  issueBody,
+  pullRequestBody = "",
+  budgets = DEFAULT_PROMPT_BUDGETS,
+  review = null,
+  reviewComments = [],
+  jobsPayload = null,
+  ciRunId = "",
+  templateText
+}) {
+  const parsedIssue = parseIssueForm(issueBody);
+  const metadata = pullRequestBody ? extractPrMetadata(pullRequestBody) || {} : {};
+  const modeConfig = STAGE_SECTION_CONFIG[mode];
+
+  if (!modeConfig) {
+    throw new Error(`Unsupported FACTORY_MODE: ${mode}`);
+  }
+
+  const promptWithoutContext = templateText
+    .replaceAll("{{ISSUE_NUMBER}}", String(issueNumber))
+    .replaceAll("{{ARTIFACTS_PATH}}", artifactsPath)
+    .replace("{{CONTEXT}}", "");
+  const contextBudget = Math.max(1000, budgets[mode] - promptWithoutContext.length);
+  const sections = buildSectionsForMode({
+    mode,
+    issueNumber,
+    prNumber,
+    branch,
+    artifactsPath,
+    parsedIssue,
+    metadata,
+    review,
+    reviewComments,
+    jobsPayload,
+    ciRunId
+  }).filter((section) => section.included && section.body);
+
+  applyPreferredCaps(sections, modeConfig);
+  fitSectionsToBudget(sections, modeConfig, contextBudget);
+
+  function renderPrompt() {
+    const orderedSections = modeConfig.order
+      .map((id) => sections.find((section) => section.id === id))
+      .filter(Boolean)
+      .filter((section) => section.included && section.body);
+    const context = orderedSections
+      .map((section) => serializeSection(section))
+      .join("\n");
+    const prompt = templateText
+      .replaceAll("{{ISSUE_NUMBER}}", String(issueNumber))
+      .replaceAll("{{ARTIFACTS_PATH}}", artifactsPath)
+      .replace("{{CONTEXT}}", context);
+
+    return { orderedSections, context, prompt };
+  }
+
+  let rendered = renderPrompt();
+
+  if (rendered.prompt.length > budgets[mode]) {
+    fitSectionsToBudget(
+      sections,
+      modeConfig,
+      Math.max(0, contextBudget - (rendered.prompt.length - budgets[mode]))
+    );
+    rendered = renderPrompt();
+  }
+
+  const { orderedSections, context, prompt } = rendered;
+  const finalChars = prompt.length;
+
+  const meta = {
+    mode,
+    budgetChars: budgets[mode],
+    hardMaxChars: budgets.hardMax,
+    contextBudgetChars: contextBudget,
+    finalChars,
+    includedSections: orderedSections.map((section) => section.id),
+    omittedSections: modeConfig.order.filter(
+      (id) => !orderedSections.some((section) => section.id === id)
+    ),
+    truncatedSections: sections
+      .filter((section) => section.truncated)
+      .map((section) => section.id),
+    sections: modeConfig.order
+      .map((id) => sections.find((section) => section.id === id) || buildSection(id, id, ""))
+      .map((section) => ({
+        id: section.id,
+        title: section.title,
+        included: section.included && Boolean(section.body),
+        dropped: section.dropped,
+        truncated: section.truncated,
+        originalChars: section.originalChars,
+        finalChars: section.body.length
+      }))
+  };
+
+  return { prompt, context, meta };
+}
+
+export function writePromptArtifacts(outputDir, { prompt, meta }) {
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, "prompt.md"), prompt);
+  fs.writeFileSync(
+    path.join(outputDir, "prompt-meta.json"),
+    JSON.stringify(meta, null, 2)
+  );
+}
+
+export async function loadStagePromptInputs(env = process.env) {
+  const mode = env.FACTORY_MODE;
+  const issueNumber = Number(env.FACTORY_ISSUE_NUMBER);
+  const prNumber = Number(env.FACTORY_PR_NUMBER || 0);
+  const branch = env.FACTORY_BRANCH;
+  const artifactsPath = env.FACTORY_ARTIFACTS_PATH;
+  const reviewId = env.FACTORY_REVIEW_ID;
+  const ciRunId = env.FACTORY_CI_RUN_ID;
+
+  if (!mode || !branch || !artifactsPath || !Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error("FACTORY_MODE, FACTORY_BRANCH, FACTORY_ARTIFACTS_PATH, and FACTORY_ISSUE_NUMBER are required");
+  }
+
+  const issue = await getIssue(issueNumber);
+  const pullRequest = prNumber > 0 ? await getPullRequest(prNumber) : null;
+  const review =
+    prNumber > 0 && reviewId && mode === "repair"
+      ? await getReview(prNumber, reviewId)
+      : null;
+  const reviewComments =
+    prNumber > 0 && reviewId && mode === "repair"
+      ? await listReviewComments(prNumber, reviewId)
+      : [];
+  const jobsPayload =
+    ciRunId && mode === "repair" ? await listWorkflowRunJobs(ciRunId) : null;
+
+  return {
+    mode,
+    issueNumber,
+    prNumber,
+    branch: pullRequest?.head?.ref || branch,
+    artifactsPath,
+    issueBody: issue.body || "",
+    pullRequestBody: pullRequest?.body || "",
+    review,
+    reviewComments,
+    jobsPayload,
+    ciRunId,
+    budgets: resolvePromptBudgets(env)
+  };
+}
+
+export async function main(env = process.env) {
+  const input = await loadStagePromptInputs(env);
+  const templatePath = path.join(".factory", "prompts", `${input.mode}.md`);
+  const templateText = fs.readFileSync(templatePath, "utf8");
+  const result = buildStagePrompt({
+    ...input,
+    templateText
+  });
+
+  writePromptArtifacts(path.join(".factory", "tmp"), result);
+
+  console.log(
+    `Prompt budget: mode=${input.mode} chars=${result.meta.finalChars}/${result.meta.budgetChars} ` +
+      `truncated=${result.meta.truncatedSections.length} omitted=${result.meta.omittedSections.length}`
+  );
+}
+
+const isDirectExecution =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/tests/build-stage-prompt.test.mjs
+++ b/tests/build-stage-prompt.test.mjs
@@ -1,0 +1,341 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildStagePrompt,
+  resolvePromptBudgets,
+  writePromptArtifacts
+} from "../scripts/build-stage-prompt.mjs";
+import { defaultPrMetadata, renderPrBody } from "../scripts/lib/pr-metadata.mjs";
+import { parseIssueForm } from "../scripts/lib/issue-form.mjs";
+
+const fixturesDir = path.join(process.cwd(), "tests", "fixtures", "prompt");
+const implementTemplate = fs.readFileSync(
+  path.join(process.cwd(), ".factory", "prompts", "implement.md"),
+  "utf8"
+);
+const planTemplate = fs.readFileSync(
+  path.join(process.cwd(), ".factory", "prompts", "plan.md"),
+  "utf8"
+);
+const repairTemplate = fs.readFileSync(
+  path.join(process.cwd(), ".factory", "prompts", "repair.md"),
+  "utf8"
+);
+
+function fixture(name) {
+  return fs.readFileSync(path.join(fixturesDir, name), "utf8");
+}
+
+function makeArtifactsDir(overrides = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "factory-prompt-"));
+  const files = {
+    "spec.md": fixture("spec.md"),
+    "plan.md": fixture("plan.md"),
+    "acceptance-tests.md": fixture("acceptance-tests.md"),
+    "repair-log.md": fixture("repair-log.md"),
+    ...overrides
+  };
+
+  for (const [fileName, contents] of Object.entries(files)) {
+    if (contents != null) {
+      fs.writeFileSync(path.join(dir, fileName), contents);
+    }
+  }
+
+  return dir;
+}
+
+function inflatedIssueBody() {
+  const extraProblem = "\n\nThe review stage must be measurable, deterministic, and auditable.";
+  const extraGoals = "\n- Keep prompt context compact while preserving enough routing detail.";
+  const extraAcceptance =
+    "\n- The generated prompt remains within the configured stage budget.";
+
+  return fixture("long-issue-body.md")
+    .replace(
+      "### Goals\n",
+      `### Goals\n${extraProblem.repeat(40)}\n`
+    )
+    .replace(
+      "### Non-goals\n",
+      `${extraGoals.repeat(40)}\n\n### Non-goals\n`
+    )
+    .replace(
+      "### Risk\n",
+      `${extraAcceptance.repeat(40)}\n\n### Risk\n`
+    );
+}
+
+function legacyIssueSections(parsedIssue) {
+  return [
+    ["Problem Statement", parsedIssue.problemStatement],
+    ["Goals", parsedIssue.goals],
+    ["Non-Goals", parsedIssue.nonGoals],
+    ["Constraints", parsedIssue.constraints],
+    ["Acceptance Criteria", parsedIssue.acceptanceCriteria],
+    ["Risk", parsedIssue.risk],
+    ["Affected Area", parsedIssue.affectedArea]
+  ]
+    .map(([title, body]) => (body ? `## ${title}\n${body.trim()}\n` : ""))
+    .join("\n");
+}
+
+function legacyArtifacts(artifactsDir) {
+  return [
+    "spec.md",
+    "plan.md",
+    "acceptance-tests.md",
+    "repair-log.md"
+  ]
+    .map((fileName) => {
+      const contents = fs.readFileSync(path.join(artifactsDir, fileName), "utf8").trim();
+      const limited =
+        contents.length > 6000 ? `${contents.slice(0, 6000)}\n...[truncated]` : contents;
+
+      return [
+        `### ${fileName}`,
+        "",
+        `\`\`\`md\n${limited}\n\`\`\``,
+        ""
+      ].join("\n");
+    })
+    .join("\n");
+}
+
+function legacyImplementPrompt({ issueBody, pullRequestBody, artifactsDir }) {
+  const parsedIssue = parseIssueForm(issueBody);
+  const context = [
+    [
+      "## Run Metadata",
+      "- Mode: implement",
+      "- Issue: #1",
+      "- Pull Request: #9",
+      "- Branch: factory/1-sample",
+      "- Current status: implementing"
+    ].join("\n"),
+    `## Issue Request\n${legacyIssueSections(parsedIssue).trim()}`,
+    `## Pull Request Summary\n${pullRequestBody.replace(/<!--\s*factory-state[\s\S]*?-->/m, "").trim()}`,
+    `## Existing Artifacts\n${legacyArtifacts(artifactsDir)}`
+  ].join("\n\n");
+
+  return implementTemplate
+    .replaceAll("{{ISSUE_NUMBER}}", "1")
+    .replaceAll("{{ARTIFACTS_PATH}}", artifactsDir)
+    .replace("{{CONTEXT}}", context);
+}
+
+test("resolvePromptBudgets honors overrides and hard ceiling", () => {
+  const budgets = resolvePromptBudgets({
+    FACTORY_PLAN_PROMPT_MAX_CHARS: "26000",
+    FACTORY_IMPLEMENT_PROMPT_MAX_CHARS: "9000",
+    FACTORY_REPAIR_PROMPT_MAX_CHARS: "15000",
+    FACTORY_PROMPT_HARD_MAX_CHARS: "10000"
+  });
+
+  assert.deepEqual(budgets, {
+    hardMax: 10000,
+    plan: 10000,
+    implement: 9000,
+    repair: 10000
+  });
+});
+
+test("plan prompt trims oversized issue sections and stays within budget", () => {
+  const artifactsDir = makeArtifactsDir();
+  const result = buildStagePrompt({
+    mode: "plan",
+    issueNumber: 1,
+    prNumber: 0,
+    branch: "factory/1-sample",
+    artifactsPath: artifactsDir,
+    issueBody: inflatedIssueBody(),
+    budgets: {
+      plan: 5500,
+      implement: 12000,
+      repair: 14000,
+      hardMax: 5500
+    },
+    templateText: planTemplate
+  });
+
+  assert.ok(result.prompt.length <= 5500, `prompt length ${result.prompt.length}`);
+  assert.ok(result.meta.truncatedSections.length > 0);
+  assert.ok(
+    result.meta.truncatedSections.includes("problem") ||
+      result.meta.truncatedSections.includes("goals") ||
+      result.meta.truncatedSections.includes("acceptance")
+  );
+  assert.match(result.prompt, /Run Metadata/);
+  assert.ok(result.meta.omittedSections.length > 0);
+});
+
+test("implement prompt excludes PR body and full artifact bodies", () => {
+  const artifactsDir = makeArtifactsDir();
+  const pullRequestBody = [
+    "PR BODY SENTINEL SHOULD NOT APPEAR",
+    "",
+    renderPrBody({
+      issueNumber: 1,
+      branch: "factory/1-sample",
+      repositoryUrl: "https://github.com/example/repo",
+      artifactsPath: artifactsDir,
+      metadata: defaultPrMetadata({
+        issueNumber: 1,
+        artifactsPath: artifactsDir,
+        status: "implementing"
+      })
+    })
+  ].join("\n");
+
+  const result = buildStagePrompt({
+    mode: "implement",
+    issueNumber: 1,
+    prNumber: 9,
+    branch: "factory/1-sample",
+    artifactsPath: artifactsDir,
+    issueBody: fixture("long-issue-body.md"),
+    pullRequestBody,
+    budgets: {
+      plan: 20000,
+      implement: 7000,
+      repair: 14000,
+      hardMax: 7000
+    },
+    templateText: implementTemplate
+  });
+
+  assert.ok(result.prompt.length <= 7000, `prompt length ${result.prompt.length}`);
+  assert.doesNotMatch(result.prompt, /PR BODY SENTINEL SHOULD NOT APPEAR/);
+  assert.doesNotMatch(
+    result.prompt,
+    /Successful CI for a factory-managed PR routes to a review stage instead/
+  );
+  assert.match(result.prompt, /Artifact Index/);
+  assert.match(result.prompt, /headings: Summary \| Workflow Flow/);
+});
+
+test("repair prompt includes failure context and capped repair-log tail", () => {
+  const longRepairLog = `${fixture("repair-log.md")}\n\n${"- extra diagnostic context\n".repeat(80)}`;
+  const artifactsDir = makeArtifactsDir({
+    "repair-log.md": longRepairLog
+  });
+  const result = buildStagePrompt({
+    mode: "repair",
+    issueNumber: 1,
+    prNumber: 9,
+    branch: "factory/1-sample",
+    artifactsPath: artifactsDir,
+    issueBody: fixture("long-issue-body.md"),
+    pullRequestBody: renderPrBody({
+      issueNumber: 1,
+      branch: "factory/1-sample",
+      repositoryUrl: "https://github.com/example/repo",
+      artifactsPath: artifactsDir,
+      metadata: defaultPrMetadata({
+        issueNumber: 1,
+        artifactsPath: artifactsDir,
+        status: "repairing"
+      })
+    }),
+    jobsPayload: {
+      jobs: [
+        {
+          name: "CI",
+          conclusion: "failure",
+          steps: [
+            { name: "test", conclusion: "failure" },
+            { name: "lint", conclusion: "success" }
+          ]
+        }
+      ]
+    },
+    ciRunId: "123456",
+    budgets: {
+      plan: 20000,
+      implement: 12000,
+      repair: 6500,
+      hardMax: 6500
+    },
+    templateText: repairTemplate
+  });
+
+  assert.ok(result.prompt.length <= 6500, `prompt length ${result.prompt.length}`);
+  assert.match(result.prompt, /Workflow run id: 123456/);
+  assert.match(result.prompt, /- CI: failure/);
+  assert.match(result.prompt, /Repair Log Tail/);
+  assert.match(result.prompt, /\.\.\.\[tail\]/);
+  assert.ok((result.prompt.match(/extra diagnostic context/g) || []).length < 40);
+});
+
+test("writePromptArtifacts emits prompt-meta.json", () => {
+  const artifactsDir = makeArtifactsDir();
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "factory-prompt-output-"));
+  const result = buildStagePrompt({
+    mode: "implement",
+    issueNumber: 1,
+    prNumber: 9,
+    branch: "factory/1-sample",
+    artifactsPath: artifactsDir,
+    issueBody: fixture("long-issue-body.md"),
+    pullRequestBody: renderPrBody({
+      issueNumber: 1,
+      branch: "factory/1-sample",
+      repositoryUrl: "https://github.com/example/repo",
+      artifactsPath: artifactsDir,
+      metadata: defaultPrMetadata({
+        issueNumber: 1,
+        artifactsPath: artifactsDir,
+        status: "implementing"
+      })
+    }),
+    templateText: implementTemplate
+  });
+
+  writePromptArtifacts(outputDir, result);
+
+  const meta = JSON.parse(
+    fs.readFileSync(path.join(outputDir, "prompt-meta.json"), "utf8")
+  );
+
+  assert.equal(meta.mode, "implement");
+  assert.equal(meta.finalChars, result.prompt.length);
+  assert.ok(Array.isArray(meta.includedSections));
+  assert.ok(Array.isArray(meta.sections));
+});
+
+test("implement prompt is materially smaller than the legacy prompt shape", () => {
+  const artifactsDir = makeArtifactsDir();
+  const issueBody = inflatedIssueBody();
+  const pullRequestBody = renderPrBody({
+    issueNumber: 1,
+    branch: "factory/1-sample",
+    repositoryUrl: "https://github.com/example/repo",
+    artifactsPath: artifactsDir,
+    metadata: defaultPrMetadata({
+      issueNumber: 1,
+      artifactsPath: artifactsDir,
+      status: "implementing"
+    })
+  });
+
+  const nextPrompt = buildStagePrompt({
+    mode: "implement",
+    issueNumber: 1,
+    prNumber: 9,
+    branch: "factory/1-sample",
+    artifactsPath: artifactsDir,
+    issueBody,
+    pullRequestBody,
+    templateText: implementTemplate
+  }).prompt;
+  const legacyPrompt = legacyImplementPrompt({
+    issueBody,
+    pullRequestBody,
+    artifactsDir
+  });
+
+  assert.ok(nextPrompt.length < legacyPrompt.length * 0.6, `${nextPrompt.length} vs ${legacyPrompt.length}`);
+});

--- a/tests/fixtures/prompt/acceptance-tests.md
+++ b/tests/fixtures/prompt/acceptance-tests.md
@@ -1,0 +1,22 @@
+# Acceptance Tests
+
+## AT1
+
+Given a factory-managed PR in `implementing`, when CI succeeds, then the PR
+enters `reviewing` and the review stage runs.
+
+## AT2
+
+Given a configured methodology that does not exist, when review prompt building
+occurs, then the system uses `default`.
+
+## AT3
+
+Given `review.json` with decision `pass`, when review processing runs, then the
+PR is marked ready for review.
+
+## AT4
+
+Given `review.json` with decision `request_changes`, when review processing
+runs, then a body-only `REQUEST_CHANGES` review is submitted and the PR remains
+draft.

--- a/tests/fixtures/prompt/long-issue-body.md
+++ b/tests/fixtures/prompt/long-issue-body.md
@@ -1,0 +1,73 @@
+### Problem statement
+
+Add a pluggable autonomous review stage to the factory so every factory-managed
+PR is reviewed after green CI and before human review. The review stage should
+use a selectable methodology, produce durable artifacts, and route failed
+reviews back into the existing repair loop without widening scope.
+
+The current factory moves directly from successful CI to human review. That
+means it skips a structured autonomous inspection step, even though the
+existing workflows already have planning artifacts, CI state, and review hooks.
+We want the review stage to evaluate the implementation against the spec, plan,
+acceptance criteria, and the diff, then either mark the PR ready or request
+changes and trigger repair.
+
+The review methodology itself needs to be pluggable so repositories can choose
+different review expectations over time without editing workflow logic. The
+default methodology should emphasize correctness, test adequacy, regression
+risk, acceptance-criteria coverage, and scope discipline.
+
+### Goals
+
+- Add a first-class review stage after successful CI.
+- Keep the pull request as the central artifact.
+- Allow repo-level methodology selection.
+- Store review output in durable markdown and JSON artifacts.
+- Reuse the existing repair loop for autonomous review findings.
+- Keep the human merge gate intact.
+- Ensure the system stays auditable and GitHub-native.
+- Keep the workflow copyable to similar repositories.
+
+### Non-goals
+
+- Multi-repo orchestration.
+- Inline file-by-file review comments in v1.
+- Arbitrary executable review plugins.
+- Autonomous merge or deploy behavior.
+- Replacing human review with AI-only approval.
+
+### Constraints
+
+- Must run entirely in GitHub Actions.
+- Must use the existing reusable stage runner.
+- Must keep work scoped to factory-managed branches and PRs.
+- Must maintain required human review on the protected default branch.
+- Must preserve the existing repair-attempt safety cap.
+- Must not require an external database or queue.
+- Must keep artifacts committed in the factory branch.
+- Must keep the implementation readable by maintainers who did not author the system.
+
+### Acceptance criteria
+
+- A factory-managed PR that reaches green CI enters `review` instead of
+  `ready_for_review`.
+- The review stage can load a methodology profile from the repository.
+- The system falls back to `default` if the configured review method is invalid.
+- The review stage writes `review.md` and `review.json` under the issue run directory.
+- A passing review marks the PR ready for human review.
+- A failing review submits a body-only `REQUEST_CHANGES` review and leaves the PR in draft.
+- A review-triggered repair reruns CI and then reruns review.
+- The factory blocks the PR after the configured repair-attempt cap is reached.
+- Existing `implement` and `repair` behavior continues to work for non-review findings.
+
+### Risk
+
+- Prompt bloat can cause quota or latency issues in the stage runner.
+- Weak schema validation on review artifacts could break automation.
+- Overly aggressive default review findings could create churn.
+- Incorrect PR state routing could deadlock the control plane.
+- Large repository context could crowd out the actually relevant failure context.
+
+### Affected area
+
+CI / Automation

--- a/tests/fixtures/prompt/plan.md
+++ b/tests/fixtures/prompt/plan.md
@@ -1,0 +1,22 @@
+# Summary
+
+Implement the review stage by extending routing, prompt construction, artifact
+handling, and PR-state transitions.
+
+## Routing
+
+Update workflow-run routing so green CI on factory-managed PRs targets review.
+
+## Prompt Infrastructure
+
+Add methodology loading, review prompt generation, and review artifact parsing.
+
+## Repair Integration
+
+Send autonomous review failures through the existing repair loop with the
+existing repair-attempt counter.
+
+## Test Coverage
+
+Cover green path, request-changes path, methodology fallback, and repair-cap
+enforcement with unit and fixture-driven tests.

--- a/tests/fixtures/prompt/repair-log.md
+++ b/tests/fixtures/prompt/repair-log.md
@@ -1,0 +1,7 @@
+# Repair Notes
+
+- CI previously failed because the review router did not inspect factory labels.
+- A later pass failed because prompt payloads were too large and drowned out the
+  actual failure signal.
+- The next repair should stay scoped to routing, prompt construction, and
+  artifact parsing.

--- a/tests/fixtures/prompt/spec.md
+++ b/tests/fixtures/prompt/spec.md
@@ -1,0 +1,23 @@
+# Summary
+
+Add an autonomous review stage to the GitHub-native factory.
+
+## Workflow Flow
+
+Successful CI for a factory-managed PR routes to a review stage instead of
+immediately marking the PR ready for human review.
+
+## Methodology Selection
+
+The active methodology is selected repo-wide by Actions variable and loaded from
+checked-in files. Invalid values fall back to `default`.
+
+## Artifact Contract
+
+The review stage must write `review.md` and `review.json` into the issue run
+directory, and those artifacts must remain committed on the factory branch.
+
+## Review Outcomes
+
+Passing review marks the PR ready. Failing review files a body-only
+`REQUEST_CHANGES` review and reuses the existing repair loop.


### PR DESCRIPTION
## Summary
- refactor stage prompt construction to be stage-aware, budgeted, and file-first
- add compact artifact indexing, prompt budget metadata, and Actions-variable tuning for stage prompt sizes
- update prompt templates and add fixture-driven tests that cover trimming behavior and prompt-size regression

## Validation
- npm test
- git diff --check