### PR TITLE
Add factory PR reset workflow

### DIFF
--- a/.github/workflows/factory-reset-pr.yml
+++ b/.github/workflows/factory-reset-pr.yml
@@ -1,0 +1,90 @@
+name: Factory Reset PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Factory-managed pull request number to reset"
+        required: true
+        type: number
+      status:
+        description: "Factory status to write into PR metadata"
+        required: true
+        default: plan_ready
+        type: choice
+        options:
+          - planning
+          - plan_ready
+          - implementing
+          - repairing
+          - blocked
+          - ready_for_review
+      convert_to_draft:
+        description: "Convert the pull request back to draft"
+        required: true
+        default: true
+        type: boolean
+      clear_repair_state:
+        description: "Reset repair counters and failure signatures"
+        required: true
+        default: true
+        type: boolean
+      add_plan_ready_label:
+        description: "Add the factory:plan-ready label"
+        required: true
+        default: true
+        type: boolean
+      remove_pause_label:
+        description: "Remove the factory:paused label too"
+        required: true
+        default: false
+        type: boolean
+      comment:
+        description: "Optional note to add to the pull request"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  reset:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Reset factory PR state
+        run: node scripts/apply-pr-state.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          FACTORY_PR_NUMBER: ${{ inputs.pr_number }}
+          FACTORY_STATUS: ${{ inputs.status }}
+          FACTORY_REPAIR_ATTEMPTS: ${{ inputs.clear_repair_state && '0' || '' }}
+          FACTORY_REPEATED_FAILURE_COUNT: ${{ inputs.clear_repair_state && '0' || '' }}
+          FACTORY_LAST_FAILURE_SIGNATURE: ${{ inputs.clear_repair_state && '' || '__UNCHANGED__' }}
+          FACTORY_CI_STATUS: pending
+          FACTORY_ADD_LABELS: ${{ inputs.add_plan_ready_label && 'factory:plan-ready' || '' }}
+          FACTORY_REMOVE_LABELS: ${{ inputs.remove_pause_label && 'factory:implement,factory:blocked,factory:paused' || 'factory:implement,factory:blocked' }}
+          FACTORY_CONVERT_TO_DRAFT: ${{ inputs.convert_to_draft && 'true' || 'false' }}
+          FACTORY_COMMENT: ${{ inputs.comment || format('Factory PR reset via workflow_dispatch. Status set to {0}.', inputs.status) }}
+
+      - name: Summarize reset
+        run: |
+          {
+            echo "## Factory Reset"
+            echo ""
+            echo "- PR: #${{ inputs.pr_number }}"
+            echo "- Status: \`${{ inputs.status }}\`"
+            echo "- Convert to draft: \`${{ inputs.convert_to_draft }}\`"
+            echo "- Clear repair state: \`${{ inputs.clear_repair_state }}\`"
+            echo "- Add \`factory:plan-ready\`: \`${{ inputs.add_plan_ready_label }}\`"
+            echo "- Remove \`factory:paused\`: \`${{ inputs.remove_pause_label }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Configure these before using the scaffold in a live repository:
 4. Apply the `factory:implement` label to start coding.
 5. Review the ready-for-review PR and merge manually when satisfied.
 
+If a factory-managed PR gets stuck in the wrong state, run `Factory Reset PR`
+from the Actions tab to restore it to `plan_ready`, clear stale repair
+counters, and convert it back to draft before retrying `factory:implement`.
+
 ## Labels
 
 The workflows create and manage these labels automatically:

--- a/scripts/apply-pr-state.mjs
+++ b/scripts/apply-pr-state.mjs
@@ -3,6 +3,7 @@ import { extractPrMetadata, renderPrBody } from "./lib/pr-metadata.mjs";
 import {
   addLabels,
   commentOnIssue,
+  convertPullRequestToDraft,
   getPullRequest,
   markReadyForReview,
   removeLabel,
@@ -29,16 +30,19 @@ const nextMetadata = {
   status: process.env.FACTORY_STATUS || metadata.status
 };
 
-if (process.env.FACTORY_REPAIR_ATTEMPTS) {
+if (process.env.FACTORY_REPAIR_ATTEMPTS !== undefined) {
   nextMetadata.repairAttempts = Number(process.env.FACTORY_REPAIR_ATTEMPTS);
 }
 
-if (process.env.FACTORY_LAST_FAILURE_SIGNATURE !== undefined) {
+if (
+  process.env.FACTORY_LAST_FAILURE_SIGNATURE !== undefined &&
+  process.env.FACTORY_LAST_FAILURE_SIGNATURE !== "__UNCHANGED__"
+) {
   nextMetadata.lastFailureSignature =
     process.env.FACTORY_LAST_FAILURE_SIGNATURE || null;
 }
 
-if (process.env.FACTORY_REPEATED_FAILURE_COUNT) {
+if (process.env.FACTORY_REPEATED_FAILURE_COUNT !== undefined) {
   nextMetadata.repeatedFailureCount = Number(
     process.env.FACTORY_REPEATED_FAILURE_COUNT
   );
@@ -65,6 +69,10 @@ for (const label of csv(process.env.FACTORY_REMOVE_LABELS)) {
 
 if (parseBoolean(process.env.FACTORY_READY_FOR_REVIEW) && pullRequest.draft) {
   await markReadyForReview(pullRequest.node_id);
+}
+
+if (parseBoolean(process.env.FACTORY_CONVERT_TO_DRAFT) && !pullRequest.draft) {
+  await convertPullRequestToDraft(pullRequest.node_id);
 }
 
 if (process.env.FACTORY_COMMENT) {

--- a/scripts/lib/github.mjs
+++ b/scripts/lib/github.mjs
@@ -206,3 +206,19 @@ export async function markReadyForReview(pullRequestId) {
     { pullRequestId }
   );
 }
+
+export async function convertPullRequestToDraft(pullRequestId) {
+  return githubGraphql(
+    `
+      mutation ConvertToDraft($pullRequestId: ID!) {
+        convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+          pullRequest {
+            id
+            isDraft
+          }
+        }
+      }
+    `,
+    { pullRequestId }
+  );
+}


### PR DESCRIPTION
## Summary
- add a manual Factory Reset PR workflow for recovering stuck factory-managed PRs
- allow apply-pr-state to clear repair counters to zero and convert a PR back to draft
- document the recovery workflow in the README

## Testing
- npm test
- node --check scripts/apply-pr-state.mjs scripts/lib/github.mjs
- git diff --check