### PR TITLE
Allow temp artifact cleanup in stage push guard

### DIFF
--- a/scripts/lib/stage-push.mjs
+++ b/scripts/lib/stage-push.mjs
@@ -32,15 +32,58 @@ export function normalizeChangedFiles(value) {
     .filter(Boolean);
 }
 
+export function parseChangedFiles(value) {
+  if (Array.isArray(value) && value.every((entry) => entry && typeof entry === "object")) {
+    return value.map(({ status = "", path = "" }) => ({
+      status: `${status}`.trim(),
+      path: `${path}`.trim()
+    }));
+  }
+
+  return normalizeChangedFiles(value).map((entry) => {
+    const [status = "", ...pathParts] = `${entry}`.split("\t");
+    const path = pathParts.join("\t").trim();
+
+    if (!path) {
+      return {
+        status: "",
+        path: status.trim()
+      };
+    }
+
+    return {
+      status: status.trim(),
+      path
+    };
+  });
+}
+
 export function hasWorkflowFileChanges(changedFiles) {
-  return normalizeChangedFiles(changedFiles).some((file) =>
-    file.startsWith(".github/workflows/")
+  return parseChangedFiles(changedFiles).some(({ path, status }) =>
+    path.startsWith(".github/workflows/") && status !== "D"
+  );
+}
+
+export function hasTempFactoryArtifactWrites(changedFiles) {
+  return parseChangedFiles(changedFiles).some(({ path, status }) =>
+    path.startsWith(".factory/tmp/") && status !== "D"
   );
 }
 
 export function evaluateStagePush({ changedFiles, hasFactoryToken }) {
-  const files = normalizeChangedFiles(changedFiles);
+  const files = parseChangedFiles(changedFiles);
   const workflowChanges = hasWorkflowFileChanges(files);
+  const tempArtifactWrites = hasTempFactoryArtifactWrites(files);
+
+  if (tempArtifactWrites) {
+    return {
+      allowed: false,
+      workflowChanges,
+      reason:
+        "Factory stage output attempted to add or modify temporary artifacts under .factory/tmp/. " +
+        "These files are workspace-only scratch space and must be cleaned up before continuing."
+    };
+  }
 
   if (workflowChanges && !hasFactoryToken) {
     return {

--- a/scripts/prepare-stage-push.mjs
+++ b/scripts/prepare-stage-push.mjs
@@ -29,9 +29,9 @@ function hasStagedChanges() {
 }
 
 function getChangedFiles(remoteHead, localHead) {
-  return git(["diff", "--name-only", `${remoteHead}..${localHead}`])
+  return git(["diff", "--name-status", `${remoteHead}..${localHead}`])
     .split("\n")
-    .map((file) => file.trim())
+    .map((entry) => entry.trim())
     .filter(Boolean);
 }
 

--- a/tests/stage-push.test.mjs
+++ b/tests/stage-push.test.mjs
@@ -2,7 +2,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   evaluateStagePush,
+  hasTempFactoryArtifactWrites,
   hasWorkflowFileChanges,
+  parseChangedFiles,
   resolveStageToken
 } from "../scripts/lib/stage-push.mjs";
 
@@ -28,18 +30,47 @@ test("resolveStageToken falls back to GITHUB_TOKEN", () => {
 
 test("hasWorkflowFileChanges only matches workflow paths", () => {
   assert.equal(
-    hasWorkflowFileChanges(["README.md", "scripts/apply-pr-state.mjs"]),
+    hasWorkflowFileChanges(["M\tREADME.md", "A\tscripts/apply-pr-state.mjs"]),
     false
   );
   assert.equal(
-    hasWorkflowFileChanges([".github/workflows/factory-pr-loop.yml"]),
+    hasWorkflowFileChanges(["M\t.github/workflows/factory-pr-loop.yml"]),
+    true
+  );
+  assert.equal(
+    hasWorkflowFileChanges(["D\t.github/workflows/factory-pr-loop.yml"]),
+    false
+  );
+});
+
+test("parseChangedFiles supports raw paths and name-status entries", () => {
+  assert.deepEqual(parseChangedFiles(["README.md"]), [
+    { status: "", path: "README.md" }
+  ]);
+  assert.deepEqual(parseChangedFiles(["M\tREADME.md", "D\t.factory/tmp/prompt.md"]), [
+    { status: "M", path: "README.md" },
+    { status: "D", path: ".factory/tmp/prompt.md" }
+  ]);
+});
+
+test("hasTempFactoryArtifactWrites only matches temp additions or modifications", () => {
+  assert.equal(
+    hasTempFactoryArtifactWrites(["D\t.factory/tmp/prompt.md"]),
+    false
+  );
+  assert.equal(
+    hasTempFactoryArtifactWrites(["M\t.factory/tmp/prompt.md"]),
+    true
+  );
+  assert.equal(
+    hasTempFactoryArtifactWrites(["A\t.factory/tmp/prompt-meta.json"]),
     true
   );
 });
 
 test("evaluateStagePush allows non-workflow changes without FACTORY_GITHUB_TOKEN", () => {
   const result = evaluateStagePush({
-    changedFiles: ["README.md", "scripts/apply-pr-state.mjs"],
+    changedFiles: ["M\tREADME.md", "A\tscripts/apply-pr-state.mjs"],
     hasFactoryToken: false
   });
 
@@ -49,7 +80,7 @@ test("evaluateStagePush allows non-workflow changes without FACTORY_GITHUB_TOKEN
 
 test("evaluateStagePush blocks workflow changes without FACTORY_GITHUB_TOKEN", () => {
   const result = evaluateStagePush({
-    changedFiles: [".github/workflows/_factory-stage.yml", "README.md"],
+    changedFiles: ["M\t.github/workflows/_factory-stage.yml", "M\tREADME.md"],
     hasFactoryToken: false
   });
 
@@ -60,10 +91,29 @@ test("evaluateStagePush blocks workflow changes without FACTORY_GITHUB_TOKEN", (
 
 test("evaluateStagePush allows workflow changes with FACTORY_GITHUB_TOKEN", () => {
   const result = evaluateStagePush({
-    changedFiles: [".github/workflows/_factory-stage.yml", "README.md"],
+    changedFiles: ["M\t.github/workflows/_factory-stage.yml", "M\tREADME.md"],
     hasFactoryToken: true
   });
 
   assert.equal(result.allowed, true);
   assert.equal(result.workflowChanges, true);
+});
+
+test("evaluateStagePush allows deleting temp artifacts", () => {
+  const result = evaluateStagePush({
+    changedFiles: ["D\t.factory/tmp/prompt.md", "M\tREADME.md"],
+    hasFactoryToken: true
+  });
+
+  assert.equal(result.allowed, true);
+});
+
+test("evaluateStagePush blocks adding temp artifacts", () => {
+  const result = evaluateStagePush({
+    changedFiles: ["A\t.factory/tmp/prompt.md", "M\tREADME.md"],
+    hasFactoryToken: true
+  });
+
+  assert.equal(result.allowed, false);
+  assert.match(result.reason, /\.factory\/tmp\//);
 });


### PR DESCRIPTION
## Summary
- parse stage push diffs with git name-status metadata
- allow deletions under .factory/tmp while still blocking writes there
- add regression tests for temp cleanup and workflow guard behavior

## Testing
- npm test