### PR TITLE
Fix factory PR issue auto-close linkage

### DIFF
--- a/scripts/lib/pr-metadata.mjs
+++ b/scripts/lib/pr-metadata.mjs
@@ -61,7 +61,7 @@ export function renderPrBody({
   return [
     "# Factory Run",
     "",
-    `Linked issue: #${issueNumber}`,
+    `Closes #${issueNumber}`,
     "",
     "## Status",
     `- Stage: ${state.status}`,

--- a/tests/pr-metadata.test.mjs
+++ b/tests/pr-metadata.test.mjs
@@ -24,5 +24,6 @@ test("renderPrBody embeds parseable metadata", () => {
   assert.equal(metadata.issueNumber, 7);
   assert.equal(metadata.artifactsPath, ".factory/runs/7");
   assert.equal(metadata.status, "plan_ready");
+  assert.match(body, /Closes #7/);
   assert.match(body, /\[spec\.md\]\(https:\/\/github\.com\/example\/repo\/blob\//);
 });


### PR DESCRIPTION
## Summary
- change the shared factory PR body renderer to use GitHub's closing keyword format
- keep the closing reference stable across later PR body rewrites by updating the shared renderer instead of only initial PR creation
- add test coverage that asserts the rendered body includes the closing keyword

## Testing
- npm test