### PR TITLE
Bootstrap factory stage artifact directories

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -133,6 +133,9 @@ jobs:
           FACTORY_REVIEW_PROMPT_MAX_CHARS: ${{ vars.FACTORY_REVIEW_PROMPT_MAX_CHARS || '' }}
           FACTORY_REVIEW_METHOD: ${{ vars.FACTORY_REVIEW_METHOD || '' }}
 
+      - name: Ensure artifacts path exists
+        run: mkdir -p "${{ inputs.artifacts_path }}"
+
       - name: Run Codex
         id: codex
         continue-on-error: true

--- a/tests/factory-config-contracts.test.mjs
+++ b/tests/factory-config-contracts.test.mjs
@@ -40,3 +40,12 @@ test("factory PR loop concurrency prefers linked PR numbers for workflow_run eve
     /github\.event\.workflow_run\.pull_requests\[0\]\.number/
   );
 });
+
+test("factory stage workflow creates the stage artifacts path before Codex runs", () => {
+  const workflowText = readWorkflowText("_factory-stage.yml");
+
+  assert.match(
+    workflowText,
+    /name:\s+Ensure artifacts path exists[\s\S]*mkdir -p "\$\{\{\s*inputs\.artifacts_path\s*\}\}"/
+  );
+});


### PR DESCRIPTION
Problem:
Fresh issue replays can start from a branch where the issue-specific artifacts path does not exist yet. In the plan stage, Codex runs under a sandbox that expects the stage artifact path to already exist as a writable root.

This caused repeated intake failures on issue #24. The rerun logs showed Codex failing before it could write planning artifacts because the sandbox expected /home/runner/work/drive/drive/.factory/runs/24 to already exist, followed by Codex completed without producing repository changes.

Fix:
- create the stage artifacts path in _factory-stage.yml before openai/codex-action@v1 runs
- add a workflow contract test so the stage runner keeps bootstrapping the artifact directory before Codex starts

Verification:
- npm test