### PR TITLE
Pin factory Codex CLI to 0.114.0

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -145,6 +145,7 @@ jobs:
           prompt-file: .factory/tmp/prompt.md
           sandbox: workspace-write
           model: ${{ vars.FACTORY_CODEX_MODEL || 'gpt-5-codex' }}
+          codex-version: 0.114.0
           codex-args: --full-auto
 
       - name: Stop on Codex failure

--- a/tests/factory-config-contracts.test.mjs
+++ b/tests/factory-config-contracts.test.mjs
@@ -49,3 +49,9 @@ test("factory stage workflow creates the stage artifacts path before Codex runs"
     /name:\s+Ensure artifacts path exists[\s\S]*mkdir -p "\$\{\{\s*inputs\.artifacts_path\s*\}\}"/
   );
 });
+
+test("factory stage workflow pins the Codex CLI to the last known good version", () => {
+  const workflowText = readWorkflowText("_factory-stage.yml");
+
+  assert.match(workflowText, /codex-version:\s*0\.114\.0/);
+});


### PR DESCRIPTION
Problem:
Factory intake and stage runs started failing after the Codex CLI version installed by openai/codex-action changed from 0.114.0 to 0.115.0. The workflow pins the action SHA, but the action installs the CLI dynamically, so the runtime changed underneath the same workflow.

Recent intake failures on issue #24 showed the same workspace-write sandbox setup succeeding on 0.114.0 and then failing on 0.115.0 with bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted.

Fix:
- pin codex-version: 0.114.0 in .github/workflows/_factory-stage.yml
- add a workflow contract test so the pin stays explicit until we intentionally move it

Verification:
- npm test