### PR TITLE
Fix review stage artifacts path wiring

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -166,6 +166,7 @@ jobs:
           FACTORY_MODE: ${{ inputs.mode }}
           FACTORY_ISSUE_NUMBER: ${{ inputs.issue_number }}
           FACTORY_BRANCH: ${{ inputs.branch }}
+          FACTORY_ARTIFACTS_PATH: ${{ inputs.artifacts_path }}
 
       - name: Stop on stage output preparation failure
         if: steps.prepare.outcome == 'failure'


### PR DESCRIPTION
## Summary
- pass `FACTORY_ARTIFACTS_PATH` into the `Prepare stage output for push` step in the reusable factory stage workflow
- restore compatibility with review-mode `prepare-stage-push.mjs`, which now requires the artifacts path
- unblock retrying PR #35, whose review stage failed on March 16, 2026 because this env var was missing on `main`

## Validation
- `git diff --check`
- inspected the failing Actions log for run `23168301451` and confirmed `prepare-stage-push.mjs` exited with `FACTORY_ARTIFACTS_PATH is required when FACTORY_MODE is "review".`

## Context
The failing run used `.github/workflows/_factory-stage.yml` from `main`, so PR #35 could not benefit from its own workflow fix until this lands.