### PR TITLE
Fix artifact guard on force-pushed branches

### DIFF
--- a/scripts/check-factory-run-artifacts.mjs
+++ b/scripts/check-factory-run-artifacts.mjs
@@ -1,5 +1,7 @@
 import fs from "node:fs";
+import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import {
   listBlockingFactoryTempArtifacts,
   listBlockingFactoryRunArtifacts,
@@ -8,11 +10,7 @@ import {
   shouldBlockFactoryRunArtifacts
 } from "./lib/factory-artifact-guard.mjs";
 
-function gitDiffChanges(range) {
-  const output = execFileSync("git", ["diff", "--name-status", range, "--"], {
-    encoding: "utf8"
-  });
-
+export function parseNameStatusOutput(output) {
   return output
     .split("\n")
     .map((line) => line.trim())
@@ -26,7 +24,56 @@ function gitDiffChanges(range) {
     });
 }
 
-function buildContext(eventName, payload) {
+function gitDiffChanges(range) {
+  const output = execFileSync("git", ["diff", "--name-status", range, "--"], {
+    encoding: "utf8"
+  });
+
+  return parseNameStatusOutput(output);
+}
+
+export function buildPushChangesFromCommits(commits = []) {
+  const changesByPath = new Map();
+
+  for (const commit of commits) {
+    for (const path of commit.added || []) {
+      changesByPath.set(path, { status: "A", path });
+    }
+
+    for (const path of commit.modified || []) {
+      changesByPath.set(path, { status: "M", path });
+    }
+
+    for (const path of commit.removed || []) {
+      changesByPath.set(path, { status: "D", path });
+    }
+  }
+
+  return [...changesByPath.values()];
+}
+
+export function resolvePushChanges(payload, diffChanges = gitDiffChanges) {
+  const range = `${payload.before}...${payload.after}`;
+
+  try {
+    return diffChanges(range);
+  } catch (error) {
+    const message = `${error?.stderr || error?.message || ""}`;
+
+    if (
+      error?.status === 128 &&
+      (message.includes("Invalid symmetric difference expression") ||
+        message.includes("bad object") ||
+        message.includes("unknown revision"))
+    ) {
+      return buildPushChangesFromCommits(payload.commits);
+    }
+
+    throw error;
+  }
+}
+
+export function buildContext(eventName, payload) {
   if (eventName === "pull_request") {
     return {
       eventName,
@@ -41,7 +88,7 @@ function buildContext(eventName, payload) {
   if (eventName === "push") {
     return {
       eventName,
-      changes: gitDiffChanges(`${payload.before}...${payload.after}`)
+      changes: resolvePushChanges(payload)
     };
   }
 
@@ -51,38 +98,49 @@ function buildContext(eventName, payload) {
   };
 }
 
-const eventName = process.env.GITHUB_EVENT_NAME || "";
-const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
-const context = buildContext(eventName, payload);
-const artifacts = listFactoryRunArtifacts(context.changes);
-const blockingArtifacts = listBlockingFactoryRunArtifacts(context.changes);
-const invalidArtifacts = listInvalidFactoryRunArtifacts(context.changes);
-const tempArtifacts = listBlockingFactoryTempArtifacts(context.changes);
+export function main(env = process.env) {
+  const eventName = env.GITHUB_EVENT_NAME || "";
+  const payload = JSON.parse(fs.readFileSync(env.GITHUB_EVENT_PATH, "utf8"));
+  const context = buildContext(eventName, payload);
+  const artifacts = listFactoryRunArtifacts(context.changes);
+  const blockingArtifacts = listBlockingFactoryRunArtifacts(context.changes);
+  const invalidArtifacts = listInvalidFactoryRunArtifacts(context.changes);
+  const tempArtifacts = listBlockingFactoryTempArtifacts(context.changes);
 
-if (!shouldBlockFactoryRunArtifacts(context)) {
-  console.log(`Factory artifact guard passed (${artifacts.length} artifact files changed).`);
-  process.exit(0);
+  if (!shouldBlockFactoryRunArtifacts(context)) {
+    console.log(`Factory artifact guard passed (${artifacts.length} artifact files changed).`);
+    return;
+  }
+
+  if (invalidArtifacts.length > 0) {
+    console.error(
+      "Only durable factory run artifacts may be added or modified under .factory/runs/**."
+    );
+  }
+
+  if (tempArtifacts.length > 0) {
+    console.error("Temporary factory artifacts under .factory/tmp/** must not be committed.");
+  }
+
+  if (
+    invalidArtifacts.length === 0 &&
+    tempArtifacts.length === 0 &&
+    blockingArtifacts.length > 0
+  ) {
+    console.error("Factory run artifacts may only be merged to main from factory/* branches.");
+  }
+
+  for (const artifact of [...invalidArtifacts, ...tempArtifacts, ...blockingArtifacts]) {
+    console.error(`- ${artifact.path}`);
+  }
+
+  process.exit(1);
 }
 
-if (invalidArtifacts.length > 0) {
-  console.error(
-    "Only durable factory run artifacts may be added or modified under .factory/runs/**."
-  );
-}
+const isDirectExecution =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
-if (tempArtifacts.length > 0) {
-  console.error("Temporary factory artifacts under .factory/tmp/** must not be committed.");
+if (isDirectExecution) {
+  main();
 }
-
-if (
-  invalidArtifacts.length === 0 &&
-  tempArtifacts.length === 0 &&
-  blockingArtifacts.length > 0
-) {
-  console.error("Factory run artifacts may only be merged to main from factory/* branches.");
-}
-
-for (const artifact of [...invalidArtifacts, ...tempArtifacts, ...blockingArtifacts]) {
-  console.error(`- ${artifact.path}`);
-}
-process.exit(1);

--- a/tests/check-factory-run-artifacts.test.mjs
+++ b/tests/check-factory-run-artifacts.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPushChangesFromCommits,
+  parseNameStatusOutput,
+  resolvePushChanges
+} from "../scripts/check-factory-run-artifacts.mjs";
+
+test("parseNameStatusOutput parses git diff name-status output", () => {
+  assert.deepEqual(
+    parseNameStatusOutput("A\t.factory/runs/1/spec.md\nM\tREADME.md\n"),
+    [
+      { status: "A", path: ".factory/runs/1/spec.md" },
+      { status: "M", path: "README.md" }
+    ]
+  );
+});
+
+test("buildPushChangesFromCommits keeps the latest status per path", () => {
+  assert.deepEqual(
+    buildPushChangesFromCommits([
+      {
+        added: [".factory/runs/1/spec.md"],
+        modified: ["README.md"],
+        removed: []
+      },
+      {
+        added: [],
+        modified: [".factory/runs/1/spec.md"],
+        removed: ["README.md"]
+      }
+    ]),
+    [
+      { status: "M", path: ".factory/runs/1/spec.md" },
+      { status: "D", path: "README.md" }
+    ]
+  );
+});
+
+test("resolvePushChanges falls back to push payload commits when diff range is invalid", () => {
+  const payload = {
+    before: "2a4a04a0a221e136b3df3933a69d2de36a3d6168",
+    after: "c216f3c6c74e94bdf9810547b3b2e0d76d55a0bf",
+    commits: [
+      {
+        added: [".factory/runs/34/review.json"],
+        modified: [".github/workflows/_factory-stage.yml"],
+        removed: []
+      }
+    ]
+  };
+
+  const changes = resolvePushChanges(payload, () => {
+    const error = new Error(
+      `fatal: Invalid symmetric difference expression ${payload.before}...${payload.after}`
+    );
+    error.status = 128;
+    error.stderr = error.message;
+    throw error;
+  });
+
+  assert.deepEqual(changes, [
+    { status: "A", path: ".factory/runs/34/review.json" },
+    { status: "M", path: ".github/workflows/_factory-stage.yml" }
+  ]);
+});
+
+test("resolvePushChanges rethrows unexpected diff failures", () => {
+  const error = new Error("permission denied");
+  error.status = 1;
+
+  assert.throws(
+    () =>
+      resolvePushChanges(
+        { before: "a", after: "b", commits: [] },
+        () => {
+          throw error;
+        }
+      ),
+    /permission denied/
+  );
+});


### PR DESCRIPTION
## Summary
- make `check-factory-run-artifacts.mjs` tolerate invalid `before...after` diff ranges on push events
- fall back to the push payload's commit file lists when a force-push or rebase makes the previous SHA unreachable
- add regression coverage for the exact failure mode seen in CI run `23170354775`

## Validation
- `git diff --check`
- `node --test tests/factory-artifact-guard.test.mjs tests/check-factory-run-artifacts.test.mjs`

## Context
The `factory-artifact-guard` job failed on March 16, 2026 in push CI run `23170354775` after PR #35 was rebased and force-pushed. The guard tried to diff `2a4a04a...c216f3c`, but the old SHA was no longer reachable, so Git rejected the symmetric diff expression and the job crashed.