### PR TITLE
Parameterize factory models per stage

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -19,6 +19,10 @@ on:
       artifacts_path:
         required: true
         type: string
+      model:
+        required: false
+        type: string
+        default: ""
       max_repair_attempts:
         required: false
         type: number
@@ -136,6 +140,18 @@ jobs:
       - name: Ensure artifacts path exists
         run: mkdir -p "${{ inputs.artifacts_path }}"
 
+      - name: Resolve stage model
+        id: model
+        run: node scripts/resolve-stage-model.mjs
+        env:
+          FACTORY_MODE: ${{ inputs.mode }}
+          FACTORY_STAGE_MODEL_OVERRIDE: ${{ inputs.model }}
+          FACTORY_CODEX_MODEL: ${{ vars.FACTORY_CODEX_MODEL || '' }}
+          FACTORY_PLAN_MODEL: ${{ vars.FACTORY_PLAN_MODEL || '' }}
+          FACTORY_IMPLEMENT_MODEL: ${{ vars.FACTORY_IMPLEMENT_MODEL || '' }}
+          FACTORY_REPAIR_MODEL: ${{ vars.FACTORY_REPAIR_MODEL || '' }}
+          FACTORY_REVIEW_MODEL: ${{ vars.FACTORY_REVIEW_MODEL || '' }}
+
       - name: Run Codex
         id: codex
         continue-on-error: true
@@ -144,7 +160,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .factory/tmp/prompt.md
           sandbox: workspace-write
-          model: ${{ inputs.mode == 'review' && (vars.FACTORY_REVIEW_MODEL || 'codex-mini-latest') || (vars.FACTORY_CODEX_MODEL || 'gpt-5-codex') }}
+          model: ${{ steps.model.outputs.model }}
           codex-version: 0.114.0
           codex-args: --full-auto
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ Configure these before using the scaffold in a live repository:
    `.github/workflows/factory-pr-loop.yml`.
 5. Protect your default branch and require normal human review for merges.
 6. Run the `Factory Bootstrap` workflow once to create the required labels.
-7. Optional: set the `FACTORY_CODEX_MODEL` Actions variable if you want to
-   override the default `gpt-5-codex` model used by the plan, implement, and
-   repair stages.
-8. Optional: set the `FACTORY_REVIEW_MODEL` Actions variable if you want to
-   override the default `codex-mini-latest` model used by the autonomous review
-   stage.
+7. Optional: set the shared `FACTORY_CODEX_MODEL` Actions variable if you want
+   one model override for the plan, implement, and repair stages.
+8. Optional: set stage-specific Actions variables to tune cost and capability
+   per stage:
+   `FACTORY_PLAN_MODEL`, `FACTORY_IMPLEMENT_MODEL`, `FACTORY_REPAIR_MODEL`,
+   and `FACTORY_REVIEW_MODEL`.
+   Stage-specific values override `FACTORY_CODEX_MODEL` for their stage.
+   Defaults are `gpt-5-codex` for plan/implement/repair and
+   `codex-mini-latest` for review.
 9. The stage runner executes Codex with `--full-auto` so planning, coding, and
    repair runs stay non-interactive inside GitHub Actions.
 10. Optional: tune prompt budgets with the following Actions variables:

--- a/scripts/lib/factory-config.mjs
+++ b/scripts/lib/factory-config.mjs
@@ -96,6 +96,20 @@ export const LABEL_DEFINITIONS = [
 export const PR_STATE_MARKER = "factory-state";
 export const DEFAULT_MAX_REPAIR_ATTEMPTS = 3;
 export const DEFAULT_CI_WORKFLOW_NAME = "CI";
+export const DEFAULT_FACTORY_CODEX_MODEL = "gpt-5-codex";
+export const DEFAULT_FACTORY_REVIEW_MODEL = "codex-mini-latest";
+export const FACTORY_STAGE_MODEL_VARIABLES = Object.freeze({
+  [FACTORY_STAGE_MODES.plan]: "FACTORY_PLAN_MODEL",
+  [FACTORY_STAGE_MODES.implement]: "FACTORY_IMPLEMENT_MODEL",
+  [FACTORY_STAGE_MODES.repair]: "FACTORY_REPAIR_MODEL",
+  [FACTORY_STAGE_MODES.review]: "FACTORY_REVIEW_MODEL"
+});
+export const DEFAULT_FACTORY_STAGE_MODELS = Object.freeze({
+  [FACTORY_STAGE_MODES.plan]: DEFAULT_FACTORY_CODEX_MODEL,
+  [FACTORY_STAGE_MODES.implement]: DEFAULT_FACTORY_CODEX_MODEL,
+  [FACTORY_STAGE_MODES.repair]: DEFAULT_FACTORY_CODEX_MODEL,
+  [FACTORY_STAGE_MODES.review]: DEFAULT_FACTORY_REVIEW_MODEL
+});
 
 export function isFactoryBranch(branchName) {
   return typeof branchName === "string" && branchName.startsWith("factory/");
@@ -103,6 +117,56 @@ export function isFactoryBranch(branchName) {
 
 export function issueArtifactsPath(issueNumber) {
   return `.factory/runs/${issueNumber}`;
+}
+
+export function isFactoryStageMode(value) {
+  return FACTORY_STAGE_MODE_VALUES.includes(`${value || ""}`.trim());
+}
+
+export function assertFactoryStageMode(value, context = "factory stage mode") {
+  const normalized = `${value || ""}`.trim();
+
+  if (!isFactoryStageMode(normalized)) {
+    throw new Error(
+      `Invalid ${context}: "${normalized || "(empty)"}". Expected one of ${FACTORY_STAGE_MODE_VALUES.join(", ")}`
+    );
+  }
+
+  return normalized;
+}
+
+function normalizeModelName(value) {
+  return `${value || ""}`.trim();
+}
+
+export function resolveFactoryStageModel({
+  mode,
+  overrideModel = "",
+  variables = process.env
+}) {
+  const normalizedMode = assertFactoryStageMode(mode);
+  const explicitOverride = normalizeModelName(overrideModel);
+
+  if (explicitOverride) {
+    return explicitOverride;
+  }
+
+  const stageVariableName = FACTORY_STAGE_MODEL_VARIABLES[normalizedMode];
+  const stageVariableModel = normalizeModelName(variables?.[stageVariableName]);
+
+  if (stageVariableModel) {
+    return stageVariableModel;
+  }
+
+  if (normalizedMode !== FACTORY_STAGE_MODES.review) {
+    const sharedCodexModel = normalizeModelName(variables?.FACTORY_CODEX_MODEL);
+
+    if (sharedCodexModel) {
+      return sharedCodexModel;
+    }
+  }
+
+  return DEFAULT_FACTORY_STAGE_MODELS[normalizedMode];
 }
 
 export function isFactoryPrStatus(value) {

--- a/scripts/resolve-stage-model.mjs
+++ b/scripts/resolve-stage-model.mjs
@@ -1,0 +1,12 @@
+import { setOutputs } from "./lib/actions-output.mjs";
+import { resolveFactoryStageModel } from "./lib/factory-config.mjs";
+
+const mode = process.env.FACTORY_MODE;
+const overrideModel = process.env.FACTORY_STAGE_MODEL_OVERRIDE || "";
+
+const model = resolveFactoryStageModel({
+  mode,
+  overrideModel
+});
+
+setOutputs({ model });

--- a/tests/factory-config-contracts.test.mjs
+++ b/tests/factory-config-contracts.test.mjs
@@ -67,12 +67,36 @@ test("factory stage workflow pins the Codex CLI to the last known good version",
   assert.match(workflowText, /codex-version:\s*0\.114\.0/);
 });
 
-test("factory stage workflow uses a dedicated cheaper model for review", () => {
+test("factory stage workflow resolves per-stage models before running Codex", () => {
   const workflowText = readWorkflowText("_factory-stage.yml");
 
   assert.match(
     workflowText,
-    /model:\s*\$\{\{\s*inputs\.mode == 'review' && \(vars\.FACTORY_REVIEW_MODEL \|\| 'codex-mini-latest'\) \|\| \(vars\.FACTORY_CODEX_MODEL \|\| 'gpt-5-codex'\)\s*\}\}/
+    /name:\s+Resolve stage model[\s\S]*node scripts\/resolve-stage-model\.mjs/
+  );
+  assert.match(
+    workflowText,
+    /FACTORY_PLAN_MODEL:\s*\$\{\{\s*vars\.FACTORY_PLAN_MODEL \|\| ''\s*\}\}/
+  );
+  assert.match(
+    workflowText,
+    /FACTORY_IMPLEMENT_MODEL:\s*\$\{\{\s*vars\.FACTORY_IMPLEMENT_MODEL \|\| ''\s*\}\}/
+  );
+  assert.match(
+    workflowText,
+    /FACTORY_REPAIR_MODEL:\s*\$\{\{\s*vars\.FACTORY_REPAIR_MODEL \|\| ''\s*\}\}/
+  );
+  assert.match(
+    workflowText,
+    /FACTORY_REVIEW_MODEL:\s*\$\{\{\s*vars\.FACTORY_REVIEW_MODEL \|\| ''\s*\}\}/
+  );
+  assert.match(
+    workflowText,
+    /FACTORY_STAGE_MODEL_OVERRIDE:\s*\$\{\{\s*inputs\.model\s*\}\}/
+  );
+  assert.match(
+    workflowText,
+    /model:\s*\$\{\{\s*steps\.model\.outputs\.model\s*\}\}/
   );
 });
 

--- a/tests/factory-config.test.mjs
+++ b/tests/factory-config.test.mjs
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_FACTORY_CODEX_MODEL,
+  DEFAULT_FACTORY_REVIEW_MODEL,
+  FACTORY_STAGE_MODES,
+  resolveFactoryStageModel
+} from "../scripts/lib/factory-config.mjs";
+
+test("resolveFactoryStageModel prefers an explicit override", () => {
+  const model = resolveFactoryStageModel({
+    mode: FACTORY_STAGE_MODES.implement,
+    overrideModel: "codex-custom-override",
+    variables: {
+      FACTORY_IMPLEMENT_MODEL: "codex-custom-stage",
+      FACTORY_CODEX_MODEL: "codex-custom-shared"
+    }
+  });
+
+  assert.equal(model, "codex-custom-override");
+});
+
+test("resolveFactoryStageModel prefers stage-specific models over shared codex model", () => {
+  const model = resolveFactoryStageModel({
+    mode: FACTORY_STAGE_MODES.repair,
+    variables: {
+      FACTORY_REPAIR_MODEL: "codex-repair-cheap",
+      FACTORY_CODEX_MODEL: "codex-shared"
+    }
+  });
+
+  assert.equal(model, "codex-repair-cheap");
+});
+
+test("resolveFactoryStageModel falls back to the shared codex model for plan, implement, and repair", () => {
+  for (const mode of [
+    FACTORY_STAGE_MODES.plan,
+    FACTORY_STAGE_MODES.implement,
+    FACTORY_STAGE_MODES.repair
+  ]) {
+    assert.equal(
+      resolveFactoryStageModel({
+        mode,
+        variables: { FACTORY_CODEX_MODEL: "codex-shared" }
+      }),
+      "codex-shared"
+    );
+  }
+});
+
+test("resolveFactoryStageModel keeps review isolated from the shared codex fallback", () => {
+  const model = resolveFactoryStageModel({
+    mode: FACTORY_STAGE_MODES.review,
+    variables: { FACTORY_CODEX_MODEL: "codex-shared" }
+  });
+
+  assert.equal(model, DEFAULT_FACTORY_REVIEW_MODEL);
+});
+
+test("resolveFactoryStageModel uses stage defaults when no overrides are provided", () => {
+  assert.equal(
+    resolveFactoryStageModel({ mode: FACTORY_STAGE_MODES.plan, variables: {} }),
+    DEFAULT_FACTORY_CODEX_MODEL
+  );
+  assert.equal(
+    resolveFactoryStageModel({ mode: FACTORY_STAGE_MODES.review, variables: {} }),
+    DEFAULT_FACTORY_REVIEW_MODEL
+  );
+});


### PR DESCRIPTION
## Summary
- add centralized stage model resolution for factory runs
- support FACTORY_PLAN_MODEL, FACTORY_IMPLEMENT_MODEL, FACTORY_REPAIR_MODEL, and FACTORY_REVIEW_MODEL
- keep FACTORY_CODEX_MODEL as the shared fallback for plan, implement, and repair
- document the repo-level stage model variables and cover the new precedence with tests

## Testing
- npm test