### PR TITLE
Fix factory intake parsing for GitHub issue form headings

### DIFF
--- a/scripts/lib/issue-form.mjs
+++ b/scripts/lib/issue-form.mjs
@@ -1,11 +1,11 @@
 const SECTION_HEADERS = {
-  "Problem statement": "problemStatement",
-  Goals: "goals",
-  "Non-goals": "nonGoals",
-  Constraints: "constraints",
-  "Acceptance criteria": "acceptanceCriteria",
-  Risk: "risk",
-  "Affected area": "affectedArea"
+  "problem statement": "problemStatement",
+  goals: "goals",
+  "non-goals": "nonGoals",
+  constraints: "constraints",
+  "acceptance criteria": "acceptanceCriteria",
+  risk: "risk",
+  "affected area": "affectedArea"
 };
 
 export function parseIssueForm(body) {
@@ -14,10 +14,10 @@ export function parseIssueForm(body) {
   let currentKey = null;
 
   for (const line of normalizedBody.split("\n")) {
-    const headingMatch = line.match(/^###\s+(.*)$/);
+    const headingMatch = line.match(/^##+\s+(.*?)\s*$/);
 
     if (headingMatch) {
-      currentKey = SECTION_HEADERS[headingMatch[1].trim()] || null;
+      currentKey = SECTION_HEADERS[headingMatch[1].trim().toLowerCase()] || null;
 
       if (currentKey && !sections[currentKey]) {
         sections[currentKey] = [];

--- a/tests/issue-form.test.mjs
+++ b/tests/issue-form.test.mjs
@@ -38,6 +38,42 @@ test("missingIssueFormFields reports omitted sections", () => {
   ]);
 });
 
+test("parseIssueForm accepts GitHub issue form heading levels", () => {
+  const parsed = parseIssueForm(`
+## Problem statement
+
+Problem text
+
+## Goals
+
+- Goal one
+
+## Non-goals
+
+- Not this
+
+## Constraints
+
+- Constraint
+
+## Acceptance criteria
+
+- Works
+
+## Risk
+
+- Risk
+
+## Affected area
+
+CI / Automation
+`);
+
+  assert.equal(isValidIssueForm(parsed), true);
+  assert.equal(parsed.problemStatement, "Problem text");
+  assert.equal(parsed.affectedArea, "CI / Automation");
+});
+
 test("slugifyIssueTitle normalizes issue titles", () => {
   assert.equal(
     slugifyIssueTitle("[Factory] Build first autonomous loop"),


### PR DESCRIPTION
## Summary
- accept GitHub issue form section headings rendered with ## during factory intake
- normalize heading matching to avoid case-sensitive misses
- add a regression test covering the issue body shape that caused issue #42 to be rejected

## Testing
- issue-form test suite passes
- build-stage-prompt test suite passes

Closes #42