### PR TITLE
fix: normalize review traceability before validation

### DIFF
--- a/.factory/prompts/review.md
+++ b/.factory/prompts/review.md
@@ -15,11 +15,10 @@ Methodology rubric:
 Deliverables (write both files inside `{{ARTIFACTS_PATH}}/`):
 
 1. `review.md`
-   - Write sections in this order: decision, `📝` Summary, `🚨` blocking findings, `⚠️` non-blocking notes, `🧭` Traceability.
+   - Write sections in this order: decision, `📝` Summary, `🚨` blocking findings, `⚠️` non-blocking notes.
    - Keep blocking findings and unmet requirements outside collapsible sections.
    - Include the methodology used (`{{METHODOLOGY_NAME}}`).
-   - Render Traceability with GitHub-friendly `<details><summary>` blocks.
-   - Treat `review.json` as the canonical source for Traceability and use the exact `Requirement`, `Status`, and `Evidence` structure for each item.
+   - The control plane renders the final `🧭` Traceability section from `review.json`; focus `review.md` on the human-readable review narrative.
 2. `review.json`
    - Include `methodology`, `decision`, `summary`, `blocking_findings_count`, `requirement_checks`, and `findings`.
    - `requirement_checks` entries must include `type`, `requirement`, `status`, and `evidence`.
@@ -30,8 +29,7 @@ Deliverables (write both files inside `{{ARTIFACTS_PATH}}/`):
 
 Validation:
 
-- Canonical traceability in `review.md` is validated against `review.json` after the run.
-- The Traceability section in `review.md` must stay structurally aligned with `review.json`; do not invent alternate field labels or prose-only summaries for traced requirements.
+- The control plane renders canonical traceability in `review.md` from `review.json` after the run.
 - `blocking_findings_count` must match the number of blocking findings.
 - A `pass` decision is only valid when every requirement check is `satisfied` or `not_applicable`.
 

--- a/scripts/lib/review-artifacts.mjs
+++ b/scripts/lib/review-artifacts.mjs
@@ -192,58 +192,11 @@ function findTraceabilityHeadingIndex(lines) {
   );
 }
 
-function isTopLevelSectionHeading(line) {
-  return /^##(?!#)\s/u.test(line.trim());
-}
-
-function isSubheading(line) {
-  return /^#{3,}\s/u.test(line.trim());
-}
-
-function isListItem(line) {
-  return /^(\s*[-*+]\s|\s*\d+\.\s)/u.test(line);
-}
-
-function isDetailsLine(line) {
-  return (
-    line.trim().startsWith("<details") ||
-    line.trim().startsWith("<summary") ||
-    line.trim().startsWith("</details>")
-  );
-}
-
-function isTraceabilityContentLine(line) {
-  return !line.trim() || isSubheading(line) || isListItem(line) || isDetailsLine(line);
-}
-
-function findTraceabilityContentEndIndex(lines, startIndex) {
-  let index = startIndex;
-  let sawStructuredTraceability = false;
-
-  while (index < lines.length && !lines[index].trim()) {
-    index += 1;
-  }
-
-  while (index < lines.length) {
-    const currentLine = lines[index];
-
-    if (isTopLevelSectionHeading(currentLine)) {
+function findNextTopLevelSectionIndex(lines, startIndex) {
+  for (let index = startIndex; index < lines.length; index += 1) {
+    if (/^##(?!#)\s/u.test(lines[index].trim())) {
       return index;
     }
-
-    if (isTraceabilityContentLine(currentLine)) {
-      if (currentLine.trim()) {
-        sawStructuredTraceability = true;
-      }
-      index += 1;
-      continue;
-    }
-
-    if (sawStructuredTraceability) {
-      return index;
-    }
-
-    index += 1;
   }
 
   return lines.length;
@@ -263,7 +216,7 @@ export function normalizeReviewMarkdownTraceability(reviewMarkdown, requirementC
       : canonicalTraceability;
   }
 
-  const trailingContentIndex = findTraceabilityContentEndIndex(lines, traceabilityIndex + 1);
+  const trailingContentIndex = findNextTopLevelSectionIndex(lines, traceabilityIndex + 1);
   const beforeTraceability = lines.slice(0, traceabilityIndex).join("\n").replace(/\s+$/u, "");
   const afterTraceability = lines.slice(trailingContentIndex).join("\n").replace(/^\s+/u, "");
 

--- a/tests/build-stage-prompt.test.mjs
+++ b/tests/build-stage-prompt.test.mjs
@@ -155,8 +155,7 @@ function legacyReviewPrompt({ artifactsDir, methodologyInstructions }) {
     "   - A Summary section using the `📝` heading.",
     "   - Blocking findings first, using a `🚨` heading and keeping them outside collapsible sections.",
     "   - Non-blocking findings or notes under a `⚠️` heading when present.",
-    "   - A `Traceability` section after findings that matches `review.json` and uses GitHub-friendly `<details><summary>` sections with the `🧭` cue.",
-    "   - Treat `review.json` as the canonical source for Traceability and use the exact `Requirement`, `Status`, and `Evidence` structure for each item.",
+    "   - The control plane renders the final `🧭` Traceability section from `review.json`; `review.md` should focus on the human-readable review narrative.",
     "   - Methodology used (`{{METHODOLOGY_NAME}}`).",
     "2. `review.json` — machine-readable artifact that must include `methodology`, `decision`, `summary`, `blocking_findings_count`, `requirement_checks`, and `findings`.",
     "",
@@ -190,25 +189,20 @@ function legacyReviewMethodologyInstructions() {
     "Review procedure:",
     "",
     "1. Read the approved `spec.md`, `plan.md`, `acceptance-tests.md`, relevant CI evidence, and the current git diff before deciding.",
-    "2. Write `review.md` in this order: decision and summary, blocking findings, non-blocking notes, then **Traceability**.",
+    "2. Write `review.md` in this order: decision and summary, blocking findings, then non-blocking notes.",
     "3. Keep blocking findings and unmet requirements outside collapsible sections so repair context stays visible in GitHub reviews.",
-    "4. Produce a compact **Traceability** section in `review.md` that covers:",
+    "4. Build explicit traceability in `review.json` for:",
     "   - every acceptance criterion",
     "   - each major spec commitment touched by the change",
     "   - each plan deliverable touched by the change",
-    "5. Render traceability as GitHub-friendly `<details><summary>` blocks, grouped by:",
-    "   - `Traceability: Acceptance Criteria`",
-    "   - `Traceability: Spec Commitments`",
-    "   - `Traceability: Plan Deliverables`",
-    "6. For every traceability item, record:",
+    "5. For every traceability item, record:",
     "   - type: `acceptance_criterion`, `spec_commitment`, or `plan_deliverable`",
     "   - requirement text",
     "   - status: `satisfied`, `partially_satisfied`, `not_satisfied`, or `not_applicable`",
     "   - concrete evidence such as changed files, tests, CI jobs, or artifact evidence",
-    "7. Use the canonical traceability block derived from `review.json` exactly, so the machine-readable and human-readable artifacts stay in sync.",
-    "   - Each traceability entry should render as `Requirement`, `Status`, and `Evidence` in that order.",
-    "8. If evidence is missing for a changed requirement, record that gap explicitly and treat it as a finding.",
-    "9. Do not issue a `pass` decision if any requirement check is `partially_satisfied` or `not_satisfied`.",
+    "6. The control plane renders the canonical `review.md` Traceability section from `review.json`; do not rely on hand-authored markdown traceability to stay in sync.",
+    "7. If evidence is missing for a changed requirement, record that gap explicitly and treat it as a finding.",
+    "8. Do not issue a `pass` decision if any requirement check is `partially_satisfied` or `not_satisfied`.",
     "",
     "Focus areas:",
     "",
@@ -374,11 +368,9 @@ test("review prompt embeds methodology instructions and metadata", () => {
   assert.match(result.prompt, /Review against these dimensions:/);
   assert.match(result.prompt, /review\.json/);
   assert.match(result.prompt, /Traceability/);
-  assert.match(result.prompt, /Render Traceability with GitHub-friendly `<details><summary>` blocks/);
-  assert.match(result.prompt, /Canonical traceability in `review\.md` is validated against `review\.json` after the run/);
-  assert.match(result.prompt, /Treat `review\.json` as the canonical source for Traceability/);
-  assert.match(result.prompt, /exact `Requirement`, `Status`, and `Evidence` structure/);
-  assert.match(result.prompt, /decision, `📝` Summary, `🚨` blocking findings, `⚠️` non-blocking notes, `🧭` Traceability/);
+  assert.match(result.prompt, /The control plane renders the final `🧭` Traceability section from `review\.json`/);
+  assert.match(result.prompt, /The control plane renders canonical traceability in `review\.md` from `review\.json` after the run/);
+  assert.match(result.prompt, /decision, `📝` Summary, `🚨` blocking findings, `⚠️` non-blocking notes/);
   assert.match(result.prompt, /requirement_checks/);
   assert.match(result.prompt, /requirement_checks` entries must include `type`, `requirement`, `status`, and `evidence`/);
   assert.match(result.prompt, /findings` entries must include `level`, `title`, `details`, `scope`, and `recommendation`/);

--- a/tests/prepare-stage-push.test.mjs
+++ b/tests/prepare-stage-push.test.mjs
@@ -265,5 +265,5 @@ test("prepare-stage-push normalizes drifted review traceability before git", () 
   const normalizedReviewMarkdown = fs.readFileSync(path.join(artifactsDir, "review.md"), "utf8");
   assert.match(normalizedReviewMarkdown, /- Requirement: Validation runs before push\./);
   assert.match(normalizedReviewMarkdown, /  - Status: `satisfied`/);
-  assert.match(normalizedReviewMarkdown, /Methodology used: default\./);
+  assert.doesNotMatch(normalizedReviewMarkdown, /Methodology used: default\./);
 });

--- a/tests/process-review.test.mjs
+++ b/tests/process-review.test.mjs
@@ -603,7 +603,7 @@ test("processReview uses configured request-changes overrides and preserves trun
 
   assert.equal(reviewPayload.event, "REQUEST_CHANGES");
   assert.match(reviewPayload.body, /# ❌ Autonomous Review Decision: REQUEST_CHANGES/);
-  assert.match(reviewPayload.body, /Review truncated after traceability details/);
+  assert.doesNotMatch(reviewPayload.body, /Review truncated after traceability details/);
   assert.match(reviewPayload.body, /Artifacts: `.+\/review\.md`/);
 });
 

--- a/tests/review-artifacts.test.mjs
+++ b/tests/review-artifacts.test.mjs
@@ -150,7 +150,6 @@ test("normalizeReviewArtifacts rewrites drifted traceability using canonical mar
 
   assert.equal(reviewMarkdown, normalizedOnDisk);
   assert.match(reviewMarkdown, /Reviewer note: retain this intro\./);
-  assert.match(reviewMarkdown, /Methodology used: default\./);
   assert.match(reviewMarkdown, /## 🧭 Traceability/);
   assert.match(reviewMarkdown, /- Requirement: Acceptance criteria are covered by automated tests\./);
   assert.match(reviewMarkdown, /  - Status: `satisfied`/);
@@ -194,7 +193,7 @@ test("normalizeReviewArtifacts replaces one-line details traceability blocks ins
   assert.match(reviewMarkdown, /- Requirement: Acceptance criteria are covered by automated tests\./);
   assert.doesNotMatch(reviewMarkdown, /Drifted evidence that should be removed\./);
   assert.doesNotMatch(reviewMarkdown, /- Acceptance Criterion:/);
-  assert.match(reviewMarkdown, /Methodology used: default\./);
+  assert.doesNotMatch(reviewMarkdown, /Methodology used: default\./);
 });
 
 test("normalizeReviewArtifacts does not treat Traceability Notes as the traceability section", () => {
@@ -268,7 +267,7 @@ test("normalizeReviewArtifacts replaces prose and subheading traceability conten
   assert.doesNotMatch(reviewMarkdown, /Drifted evidence that should be removed\./);
 });
 
-test("normalizeReviewArtifacts preserves trailing prose after structured traceability content", () => {
+test("normalizeReviewArtifacts discards unheaded prose after the replaced traceability section", () => {
   const artifactsPath = createArtifacts();
   const reviewMdPath = path.join(artifactsPath, "review.md");
 
@@ -299,8 +298,8 @@ test("normalizeReviewArtifacts preserves trailing prose after structured traceab
     requestedMethodology: "default"
   });
 
-  assert.match(reviewMarkdown, /Methodology used: default\./);
-  assert.match(reviewMarkdown, /Closing reviewer note\./);
+  assert.doesNotMatch(reviewMarkdown, /Methodology used: default\./);
+  assert.doesNotMatch(reviewMarkdown, /Closing reviewer note\./);
   assert.doesNotMatch(reviewMarkdown, /Drifted evidence that should be removed\./);
 });
 


### PR DESCRIPTION
## Problem Statement
The factory review stage has been brittle because it treated the model-authored `review.md` Traceability section as part of the validation contract. In practice, the model often produced semantically correct but structurally different traceability markdown, which blocked review-stage processing even when `review.json` contained the right machine-readable review data.

PR #44 exposed the original failure mode: drift between `review.md` and the canonical traceability implied by `review.json` caused the review stage to fail before processing. Subsequent review on this PR also showed that trying to normalize arbitrary model-authored markdown into the canonical traceability shape leads to a growing parser surface and repeated edge cases.

## Overall Goal
Make the review pipeline deterministic by treating `review.json` as the single source of truth for traceability and having the control plane render the final `review.md` Traceability section from it.

That keeps the machine-readable contract authoritative while preserving `review.md` as the human-readable review artifact for decision, summary, findings, and reviewer narrative.

## Pivot For Reviewers
This PR started as a narrower normalization fix, but it has intentionally pivoted.

Earlier revisions tried to repair model-authored Traceability in place by parsing and rewriting the existing markdown section. Review feedback made it clear that this approach was the wrong abstraction boundary: every new markdown variant expanded the parser and created more edge cases around what should be preserved or discarded.

The current design removes that parsing-heavy approach. Instead, the control plane now:
- validates `review.json` as before
- treats `review.json` as authoritative for traceability
- strips any existing `Traceability` section body from `review.md`
- renders the canonical Traceability block from `review.json`
- preserves prose before Traceability and later top-level sections after it

So if you reviewed an earlier revision of this PR, the important change is that Traceability is now control-plane-owned, not model-owned.

## Reviewer Context
The core behavior change is in `scripts/lib/review-artifacts.mjs`.
- `review.md` is normalized by split/rebuild rather than by trying to parse traceability internals.
- The accepted Traceability headings remain `## 🧭 Traceability` and `## Traceability`.
- Unheaded prose directly inside the old Traceability section is intentionally discarded; later top-level `##` sections are preserved.
- `review.json` schema is unchanged in this PR. In particular, `requirement_checks[*].evidence` is still a required non-empty string.

The review prompt was updated so the model no longer has to hand-render Traceability in `review.md`; it still must produce complete `review.json` requirement checks and the human-readable review narrative.

## Testing
- `npm test`
- Added/updated tests for:
  - replacing non-canonical traceability with the canonical block from `review.json`
  - removing one-line `<details><summary>...` drift and prose/subheading drift under Traceability
  - appending canonical Traceability when missing
  - preserving later top-level sections after Traceability
  - keeping review comment rendering and truncation behavior stable under the new contract