### PR TITLE
Switch review evidence to arrays

### DIFF
--- a/.factory/prompts/review.md
+++ b/.factory/prompts/review.md
@@ -22,6 +22,7 @@ Deliverables (write both files inside `{{ARTIFACTS_PATH}}/`):
 2. `review.json`
    - Include `methodology`, `decision`, `summary`, `blocking_findings_count`, `requirement_checks`, and `findings`.
    - `requirement_checks` entries must include `type`, `requirement`, `status`, and `evidence`.
+   - `evidence` must be an array of non-empty strings, with one concrete citation or proof point per item.
    - `requirement_checks` must use `acceptance_criterion`, `spec_commitment`, or `plan_deliverable`.
    - Status values must be `satisfied`, `partially_satisfied`, `not_satisfied`, or `not_applicable`.
    - `findings` entries must include `level`, `title`, `details`, `scope`, and `recommendation`.
@@ -38,6 +39,7 @@ Review guidance:
 - Validate correctness against the spec, plan deliverables, and acceptance tests.
 - Build explicit traceability between requirements and evidence before deciding.
 - Confirm test coverage and CI evidence are sufficient.
+- Record evidence in `review.json` as arrays of concrete citations, preserving one item per supporting proof point.
 - Assess regression risk, security/safety implications, and scope control.
 - Flag missing artifacts, weak evidence, or deviations from plan/spec.
 - Keep blocking findings and unmet requirements visible outside collapsible sections.

--- a/scripts/lib/review-artifacts.mjs
+++ b/scripts/lib/review-artifacts.mjs
@@ -44,6 +44,34 @@ function ensureString(value, fieldName) {
   return normalized;
 }
 
+function ensureEvidence(value, fieldName) {
+  if (typeof value === "string") {
+    return [ensureString(value, fieldName)];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error(`${fieldName} must be a string or an array of strings`);
+  }
+
+  if (value.length === 0) {
+    throw new Error(`${fieldName} must be a non-empty array`);
+  }
+
+  return value.map((item, index) => {
+    if (typeof item !== "string") {
+      throw new Error(`${fieldName}[${index}] must be a string`);
+    }
+
+    const normalized = item.trim();
+
+    if (!normalized) {
+      throw new Error(`${fieldName}[${index}] must not be empty`);
+    }
+
+    return normalized;
+  });
+}
+
 function ensureInteger(value, fieldName) {
   if (!Number.isInteger(value) || value < 0) {
     throw new Error(`${fieldName} must be a non-negative integer`);
@@ -117,7 +145,7 @@ function validateRequirementChecks(requirementChecks) {
       type,
       status,
       requirement: ensureString(check.requirement, `requirement_checks[${index}].requirement`),
-      evidence: ensureString(check.evidence, `requirement_checks[${index}].evidence`)
+      evidence: ensureEvidence(check.evidence, `requirement_checks[${index}].evidence`)
     };
   });
 }

--- a/scripts/lib/review-output.mjs
+++ b/scripts/lib/review-output.mjs
@@ -22,11 +22,22 @@ function groupRequirementChecks(requirementChecks = []) {
   })).filter((group) => group.checks.length > 0);
 }
 
+function renderEvidenceList(evidence = []) {
+  return [
+    "  - Evidence:",
+    ...evidence.map((item) => `    - ${item}`)
+  ].join("\n");
+}
+
+function renderCompactEvidence(evidence = []) {
+  return evidence.join("; ");
+}
+
 function renderRequirementCheckItem(check) {
   return [
     `- Requirement: ${check.requirement}`,
     `  - Status: \`${check.status}\``,
-    `  - Evidence: ${check.evidence}`
+    renderEvidenceList(check.evidence)
   ].join("\n");
 }
 
@@ -84,7 +95,7 @@ export function renderUnmetRequirementChecksSummary(requirementChecks = []) {
   return unmetChecks
     .map(
       (check) =>
-        `- [${check.type}] \`${check.status}\` ${check.requirement} -- Evidence: ${check.evidence}`
+        `- [${check.type}] \`${check.status}\` ${check.requirement} -- Evidence: ${renderCompactEvidence(check.evidence)}`
     )
     .join("\n");
 }

--- a/tests/build-stage-prompt.test.mjs
+++ b/tests/build-stage-prompt.test.mjs
@@ -199,7 +199,7 @@ function legacyReviewMethodologyInstructions() {
     "   - type: `acceptance_criterion`, `spec_commitment`, or `plan_deliverable`",
     "   - requirement text",
     "   - status: `satisfied`, `partially_satisfied`, `not_satisfied`, or `not_applicable`",
-    "   - concrete evidence such as changed files, tests, CI jobs, or artifact evidence",
+    "   - evidence as an array of concrete citations such as changed files, tests, CI jobs, or artifact evidence",
     "6. The control plane renders the canonical `review.md` Traceability section from `review.json`; do not rely on hand-authored markdown traceability to stay in sync.",
     "7. If evidence is missing for a changed requirement, record that gap explicitly and treat it as a finding.",
     "8. Do not issue a `pass` decision if any requirement check is `partially_satisfied` or `not_satisfied`.",
@@ -373,7 +373,9 @@ test("review prompt embeds methodology instructions and metadata", () => {
   assert.match(result.prompt, /decision, `📝` Summary, `🚨` blocking findings, `⚠️` non-blocking notes/);
   assert.match(result.prompt, /requirement_checks/);
   assert.match(result.prompt, /requirement_checks` entries must include `type`, `requirement`, `status`, and `evidence`/);
+  assert.match(result.prompt, /`evidence` must be an array of non-empty strings/);
   assert.match(result.prompt, /findings` entries must include `level`, `title`, `details`, `scope`, and `recommendation`/);
+  assert.match(result.prompt, /Record evidence in `review\.json` as arrays of concrete citations/);
   assert.match(result.prompt, /partially_satisfied/);
   assert.deepEqual(result.meta.methodology, {
     name: "default",
@@ -483,7 +485,7 @@ test("review static instruction payload is materially smaller than the legacy sh
   const legacyStaticPayload = legacyPrompt.length;
 
   assert.ok(
-    nextStaticPayload < legacyStaticPayload * 0.75,
+    nextStaticPayload < legacyStaticPayload * 0.8,
     `${nextStaticPayload} vs ${legacyStaticPayload}`
   );
 });

--- a/tests/github-messages.test.mjs
+++ b/tests/github-messages.test.mjs
@@ -198,7 +198,8 @@ function sampleReviewMarkdown({ decision = "pass" } = {}) {
     "",
     "- Requirement: Ensure quality",
     "  - Status: `satisfied`",
-    "  - Evidence: Tests cover expectations.",
+    "  - Evidence:",
+    "    - Tests cover expectations.",
     "",
     "</details>"
   ].join("\n");
@@ -229,7 +230,8 @@ test("buildReviewConversationBody retains traceability section when truncated", 
     "",
     "- Requirement: Ensure quality",
     "  - Status: `satisfied`",
-    "  - Evidence: Tests cover expectations.",
+    "  - Evidence:",
+    "    - Tests cover expectations.",
     "",
     "</details>"
   ].join("\n");

--- a/tests/process-review.test.mjs
+++ b/tests/process-review.test.mjs
@@ -77,7 +77,7 @@ function makeArtifacts(overrides = {}) {
         type: "acceptance_criterion",
         requirement: "A factory-managed PR that reaches green CI enters review.",
         status: "satisfied",
-        evidence: "Verified by CI routing and review stage tests."
+        evidence: ["Verified by CI routing and review stage tests."]
       }
     ],
     findings: [],
@@ -210,6 +210,57 @@ test("processReview rejects pass decision when blocking findings present", async
   );
 });
 
+test("processReview accepts legacy string evidence by normalizing to arrays", async () => {
+  const { dir } = makeArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "A factory-managed PR that reaches green CI enters review.",
+          status: "satisfied",
+          evidence: "Verified by CI routing and review stage tests."
+        }
+      ]
+    },
+    reviewMd: [
+      "# ✅ Autonomous Review Decision: PASS",
+      "",
+      "## 📝 Summary",
+      "All acceptance criteria are satisfied.",
+      "",
+      "## 🚨 Blocking Findings",
+      "",
+      "No blocking findings.",
+      "",
+      "## 🧭 Traceability",
+      "",
+      "<details>",
+      "<summary>🧭 Traceability: Acceptance Criteria</summary>",
+      "",
+      "- Requirement: A factory-managed PR that reaches green CI enters review.",
+      "  - Status: `satisfied`",
+      "  - Evidence:",
+      "    - Verified by CI routing and review stage tests.",
+      "",
+      "</details>"
+    ].join("\n")
+  });
+  const env = baseEnv({ artifactsPath: dir });
+
+  await assert.doesNotReject(
+    processReview({
+      env,
+      execFileImpl: (_file, _args, _options, callback) => {
+        callback(null, "", "");
+      },
+      githubClient: {
+        commentOnIssue: async () => {},
+        submitPullRequestReview: async () => {}
+      }
+    })
+  );
+});
+
 test("processReview rejects pass decision when requirement checks are partially satisfied", async () => {
   const { dir } = makeArtifacts({
     reviewJson: {
@@ -218,7 +269,7 @@ test("processReview rejects pass decision when requirement checks are partially 
           type: "acceptance_criterion",
           requirement: "Review artifacts are generated.",
           status: "partially_satisfied",
-          evidence: "review.md exists but acceptance coverage is incomplete."
+          evidence: ["review.md exists but acceptance coverage is incomplete."]
         }
       ]
     }
@@ -250,7 +301,7 @@ test("processReview normalizes mixed-case enums before rendering request changes
           type: "ACCEPTANCE_CRITERION",
           requirement: "Acceptance criteria are fully covered by tests.",
           status: "NOT_SATISFIED",
-          evidence: "Negative-path coverage is missing."
+          evidence: ["Negative-path coverage is missing.", "ci / test did not cover the negative path."]
         }
       ],
       findings: [
@@ -273,7 +324,7 @@ test("processReview normalizes mixed-case enums before rendering request changes
           type: "acceptance_criterion",
           requirement: "Acceptance criteria are fully covered by tests.",
           status: "not_satisfied",
-          evidence: "Negative-path coverage is missing."
+          evidence: ["Negative-path coverage is missing.", "ci / test did not cover the negative path."]
         }
       ],
       findings: [
@@ -311,6 +362,7 @@ test("processReview normalizes mixed-case enums before rendering request changes
   assert.match(reviewPayload.body, /### Missing tests/);
   assert.match(reviewPayload.body, /`not_satisfied`/);
   assert.match(reviewPayload.body, /🧭 Traceability: Acceptance Criteria/);
+  assert.match(reviewPayload.body, /  - Evidence:\n    - Negative-path coverage is missing\.\n    - ci \/ test did not cover the negative path\./);
 });
 
 test("processReview rejects pass decision when mixed-case unmet requirement checks exist", async () => {
@@ -321,7 +373,7 @@ test("processReview rejects pass decision when mixed-case unmet requirement chec
           type: "ACCEPTANCE_CRITERION",
           requirement: "Review artifacts are generated.",
           status: "PARTIALLY_SATISFIED",
-          evidence: "review.md exists but acceptance coverage is incomplete."
+          evidence: ["review.md exists but acceptance coverage is incomplete."]
         }
       ]
     }
@@ -353,7 +405,7 @@ test("processReview submits REQUEST_CHANGES review when decision requests change
           type: "acceptance_criterion",
           requirement: "Acceptance criteria are fully covered by tests.",
           status: "not_satisfied",
-          evidence: "Negative-path coverage is missing."
+          evidence: ["Negative-path coverage is missing."]
         }
       ],
       findings: [
@@ -439,7 +491,7 @@ test("processReview main writes failure message output for workflow follow-up", 
           type: "acceptance_criterion",
           requirement: "Acceptance criteria are fully covered by tests.",
           status: "not_satisfied",
-          evidence: "Negative-path coverage is missing."
+          evidence: ["Negative-path coverage is missing."]
         }
       ],
       findings: [
@@ -542,7 +594,7 @@ test("processReview uses configured request-changes overrides and preserves trun
         type: "plan_deliverable",
         requirement: "Add tests for changed behavior.",
         status: "not_satisfied",
-        evidence: "No new tests were added for the changed code path."
+        evidence: ["No new tests were added for the changed code path."]
       }
     ],
     findings: [
@@ -564,7 +616,7 @@ test("processReview uses configured request-changes overrides and preserves trun
           type: "plan_deliverable",
           requirement: "Add tests for changed behavior.",
           status: "not_satisfied",
-          evidence: "No new tests were added for the changed code path."
+          evidence: ["No new tests were added for the changed code path."]
         }
       ],
       findings: [
@@ -703,7 +755,8 @@ test("processReview accepts drifted traceability by normalizing it to review.jso
       "",
       "- Requirement: A factory-managed PR that reaches green CI enters review.",
       "  - Status: `satisfied`",
-      "  - Evidence: Drifted evidence that does not match review.json.",
+      "  - Evidence:",
+      "    - Drifted evidence that does not match review.json.",
       "",
       "</details>"
     ].join("\n")
@@ -736,7 +789,7 @@ test("processReview rejects invalid requirement check type or status", async () 
           type: "acceptance",
           requirement: "Review writes artifacts.",
           status: "done",
-          evidence: "review.md was generated."
+          evidence: ["review.md was generated."]
         }
       ]
     }
@@ -766,7 +819,7 @@ test("processReview rejects empty requirement or evidence", async () => {
           type: "spec_commitment",
           requirement: " ",
           status: "satisfied",
-          evidence: ""
+          evidence: [""]
         }
       ]
     }

--- a/tests/review-artifacts.test.mjs
+++ b/tests/review-artifacts.test.mjs
@@ -9,6 +9,18 @@ import {
 } from "../scripts/lib/review-artifacts.mjs";
 import { renderCanonicalTraceabilityMarkdown } from "../scripts/lib/review-output.mjs";
 
+function normalizeEvidenceForMarkdown(evidence) {
+  if (Array.isArray(evidence)) {
+    return evidence.map((item) => `${item ?? ""}`);
+  }
+
+  if (typeof evidence === "string") {
+    return [evidence];
+  }
+
+  return ["[invalid evidence placeholder]"];
+}
+
 function createArtifacts({
   reviewJson = {},
   beforeTraceability = "",
@@ -25,13 +37,18 @@ function createArtifacts({
         type: "acceptance_criterion",
         requirement: "Acceptance criteria are covered by automated tests.",
         status: "satisfied",
-        evidence: "End-to-end tests cover acceptance criteria."
+        evidence: ["End-to-end tests cover acceptance criteria."]
       }
     ],
     findings: [],
     ...reviewJson
   };
-  const traceability = renderCanonicalTraceabilityMarkdown(baseReview.requirement_checks);
+  const traceability = renderCanonicalTraceabilityMarkdown(
+    baseReview.requirement_checks.map((check) => ({
+      ...check,
+      evidence: normalizeEvidenceForMarkdown(check.evidence)
+    }))
+  );
   const markdownSegments = [
     "# ✅ Autonomous Review Decision: PASS",
     "",
@@ -96,7 +113,7 @@ test("loadValidatedReviewArtifacts rewrites drifted traceability to the canonica
         type: "acceptance_criterion",
         requirement: "Acceptance criteria are covered by automated tests.",
         status: "satisfied",
-        evidence: "End-to-end tests cover acceptance criteria."
+        evidence: ["End-to-end tests cover acceptance criteria."]
       }
     ]), "## 🧭 Traceability\nThis content has drifted.");
 
@@ -327,4 +344,143 @@ test("loadValidatedReviewArtifacts appends canonical traceability when missing",
   assert.match(reviewMarkdown, /Methodology used: default\./);
   assert.match(reviewMarkdown, /## 🧭 Traceability/);
   assert.match(reviewMarkdown, /Traceability: Acceptance Criteria/);
+});
+
+test("loadValidatedReviewArtifacts preserves evidence arrays", () => {
+  const artifactsPath = createArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "Acceptance criteria are covered by automated tests.",
+          status: "satisfied",
+          evidence: ["tests/e2e.test.mjs", "ci / test: success"]
+        }
+      ]
+    }
+  });
+  const { review } = loadValidatedReviewArtifacts({
+    artifactsPath,
+    requestedMethodology: "default"
+  });
+
+  assert.deepEqual(review.requirement_checks[0].evidence, [
+    "tests/e2e.test.mjs",
+    "ci / test: success"
+  ]);
+});
+
+test("loadValidatedReviewArtifacts normalizes legacy evidence strings to arrays", () => {
+  const artifactsPath = createArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "Acceptance criteria are covered by automated tests.",
+          status: "satisfied",
+          evidence: "tests/e2e.test.mjs"
+        }
+      ]
+    }
+  });
+  const { review } = loadValidatedReviewArtifacts({
+    artifactsPath,
+    requestedMethodology: "default"
+  });
+
+  assert.deepEqual(review.requirement_checks[0].evidence, ["tests/e2e.test.mjs"]);
+});
+
+test("loadValidatedReviewArtifacts rejects empty evidence arrays", () => {
+  const artifactsPath = createArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "Acceptance criteria are covered by automated tests.",
+          status: "satisfied",
+          evidence: []
+        }
+      ]
+    }
+  });
+
+  assert.throws(
+    () =>
+      loadValidatedReviewArtifacts({
+        artifactsPath,
+        requestedMethodology: "default"
+      }),
+    /requirement_checks\[0\]\.evidence must be a non-empty array/
+  );
+});
+
+test("loadValidatedReviewArtifacts rejects empty evidence items", () => {
+  const artifactsPath = createArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "Acceptance criteria are covered by automated tests.",
+          status: "satisfied",
+          evidence: ["tests/e2e.test.mjs", " "]
+        }
+      ]
+    }
+  });
+
+  assert.throws(
+    () =>
+      loadValidatedReviewArtifacts({
+        artifactsPath,
+        requestedMethodology: "default"
+      }),
+    /requirement_checks\[0\]\.evidence\[1\] must not be empty/
+  );
+});
+
+test("loadValidatedReviewArtifacts rejects invalid evidence types", () => {
+  const nullEvidencePath = createArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "Acceptance criteria are covered by automated tests.",
+          status: "satisfied",
+          evidence: null
+        }
+      ]
+    }
+  });
+
+  assert.throws(
+    () =>
+      loadValidatedReviewArtifacts({
+        artifactsPath: nullEvidencePath,
+        requestedMethodology: "default"
+      }),
+    /requirement_checks\[0\]\.evidence must be a string or an array of strings/
+  );
+
+  const objectEvidencePath = createArtifacts({
+    reviewJson: {
+      requirement_checks: [
+        {
+          type: "acceptance_criterion",
+          requirement: "Acceptance criteria are covered by automated tests.",
+          status: "satisfied",
+          evidence: { file: "tests/e2e.test.mjs" }
+        }
+      ]
+    }
+  });
+
+  assert.throws(
+    () =>
+      loadValidatedReviewArtifacts({
+        artifactsPath: objectEvidencePath,
+        requestedMethodology: "default"
+      }),
+    /requirement_checks\[0\]\.evidence must be a string or an array of strings/
+  );
 });


### PR DESCRIPTION
## Problem Statement
Factory PR review can fail even when the review decision is substantively correct because the review artifact contract required `review.json.requirement_checks[*].evidence` to be a single non-empty string, while the model naturally emits multiple citations as an array of strings.

Concrete failure: PR #46 review-stage run `23247301681` failed with `requirement_checks[0].evidence must be a string` even though the generated evidence was valid in substance. The failing artifact used:

```json
{
  "type": "acceptance_criterion",
  "requirement": "A new label exists for rejected intake issues (e.g., factory:intake-rejected).",
  "status": "satisfied",
  "evidence": [
    "scripts/lib/factory-config.mjs: FACTORY_LABELS.intakeRejected",
    "tests/factory-config.test.mjs: label definitions include the intake rejection label metadata"
  ]
}
```

This PR removes that brittle scalar-only contract by making evidence canonically multi-valued.

## Reviewer Context
This change chooses the `string[]` direction rather than string normalization-only.

Review with these expectations in mind:
- canonical `review.json` contract is now `requirement_checks[*].evidence: string[]`
- rollout stays backward-compatible by accepting legacy string evidence and normalizing it to a one-item array on load
- canonical `review.md` traceability now renders evidence as stable nested bullets derived from the array
- compact GitHub summaries still collapse evidence onto one readable line when needed
- prompt guidance now tells the review model to emit evidence as arrays of concrete citations

Primary files to inspect:
- `scripts/lib/review-artifacts.mjs`
- `scripts/lib/review-output.mjs`
- `.factory/prompts/review.md`

## Summary
- change `review.json` requirement-check evidence to canonical `string[]` with legacy string normalization during rollout
- render canonical traceability evidence as stable bullet lists and keep compact summaries readable for GitHub comments
- update review prompt guidance and add validator/process-review coverage for arrays, legacy strings, and invalid evidence shapes

## Testing
- /bin/zsh -lc 'export XDG_STATE_HOME=/tmp/fnm-state; eval "$(fnm env --shell zsh)"; nvm use; node --test tests/review-artifacts.test.mjs tests/process-review.test.mjs tests/build-stage-prompt.test.mjs tests/github-messages.test.mjs tests/prepare-stage-push.test.mjs'