### PR TITLE
Harden factory workflow permissions

### DIFF
--- a/.github/workflows/factory-bootstrap.yml
+++ b/.github/workflows/factory-bootstrap.yml
@@ -33,7 +33,7 @@ jobs:
             echo ""
             echo "Required repository setup:"
             echo "- Add the \`OPENAI_API_KEY\` repository secret."
-            echo "- Set Actions workflow permissions to Read and write."
+            echo "- Set default Actions workflow permissions to Read repository contents and packages."
             echo "- Allow GitHub Actions to create pull requests."
             echo "- Keep the CI workflow named \`CI\`, or update the workflow_run trigger in \`factory-pr-loop.yml\`."
             echo "- Protect the default branch and require human review for merges."

--- a/.github/workflows/factory-intake.yml
+++ b/.github/workflows/factory-intake.yml
@@ -6,14 +6,15 @@ on:
       - labeled
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   prepare:
     if: github.event.label.name == 'factory:start'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     outputs:
       issue_number: ${{ steps.prepare.outputs.issue_number }}
       pr_number: ${{ steps.prepare.outputs.pr_number }}
@@ -62,6 +63,10 @@ jobs:
       - prepare
       - plan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/factory-pr-loop.yml
+++ b/.github/workflows/factory-pr-loop.yml
@@ -18,13 +18,14 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   route:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       action: ${{ steps.route.outputs.action }}
       pr_number: ${{ steps.route.outputs.pr_number }}
@@ -51,13 +52,16 @@ jobs:
         id: route
         run: node scripts/route-pr-loop.mjs
         env:
-          FACTORY_GITHUB_TOKEN: ${{ secrets.FACTORY_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
 
   mark-in-progress:
     if: needs.route.outputs.action == 'implement' || needs.route.outputs.action == 'repair' || needs.route.outputs.action == 'review'
     needs: route
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -106,6 +110,9 @@ jobs:
       - route
       - stage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -131,6 +138,10 @@ jobs:
       - route
       - stage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -213,6 +224,10 @@ jobs:
     if: needs.route.outputs.action == 'blocked'
     needs: route
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -244,6 +259,10 @@ jobs:
       - mark-in-progress
       - stage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     outputs:
       failure_message: ${{ steps.process_review.outputs.failure_message }}
       failure_type: ${{ steps.process_review.outputs.failure_type }}
@@ -287,6 +306,10 @@ jobs:
       - route
       - process-review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem Statement
The repo-wide default `GITHUB_TOKEN` permission has been reduced to read-only, but the factory workflows were still declaring broad workflow-level write permissions. That leaves more jobs and more tokens with write authority than they need, which increases blast radius in a public repository.

## What Changed
- narrowed `factory-intake` from workflow-wide write access to per-job permissions
- narrowed `factory-pr-loop` from workflow-wide write access to per-job permissions
- removed the unnecessary `FACTORY_GITHUB_TOKEN` from the low-privilege routing job
- updated bootstrap guidance to reflect the new repo default Actions permission setting

## Reviewer Context
This PR is intended as a least-privilege cleanup after switching the repository default workflow permissions to `read`.

The goal is not to change factory behavior. The goal is to make the privilege boundaries explicit so that:
- read-only jobs stay read-only
- jobs that mutate branches, labels, PR metadata, or comments still request write explicitly
- the bootstrap documentation no longer instructs maintainers to restore the old broad default

## What To Verify
- `factory-intake` can still create the planning branch and finalize the PR/issue state
- `factory-pr-loop` can still update PR metadata, labels, comments, and failure handling paths
- the `route` job still resolves actions correctly with only read access
- workflow YAML remains valid

## Validation
- parsed the edited workflow YAML successfully
- confirmed the repository default workflow permission is now `read`