### PR TITLE
Authorize review-triggered factory repairs

### DIFF
--- a/scripts/lib/event-router.mjs
+++ b/scripts/lib/event-router.mjs
@@ -9,6 +9,9 @@ import {
 import { extractPrMetadata } from "./pr-metadata.mjs";
 import { nextRepairState } from "./repair-state.mjs";
 
+const TRUSTED_REVIEW_PERMISSIONS = new Set(["write", "maintain", "admin"]);
+const TRUSTED_AUTOMATION_REVIEWERS = new Set(["github-actions[bot]", "app/github-actions"]);
+
 function hasLabel(labels, labelName) {
   return labels.some((label) => label.name === labelName);
 }
@@ -20,6 +23,16 @@ function isManaged(labels, branchName, metadata) {
     hasLabel(labels, FACTORY_LABELS.managed) &&
     !hasLabel(labels, FACTORY_LABELS.paused) &&
     !hasLabel(labels, FACTORY_LABELS.blocked)
+  );
+}
+
+export function isTrustedReviewTrigger({ reviewerLogin, reviewerPermission } = {}) {
+  const normalizedLogin = `${reviewerLogin || ""}`.trim();
+  const normalizedPermission = `${reviewerPermission || ""}`.trim().toLowerCase();
+
+  return (
+    TRUSTED_AUTOMATION_REVIEWERS.has(normalizedLogin) ||
+    TRUSTED_REVIEW_PERMISSIONS.has(normalizedPermission)
   );
 }
 
@@ -49,12 +62,15 @@ export function routePullRequestLabeled(payload) {
 export function routePullRequestReview(payload) {
   const pullRequest = payload.pull_request;
   const metadata = extractPrMetadata(pullRequest.body);
+  const reviewerLogin = payload.review?.user?.login || "";
+  const reviewerPermission = payload.reviewerPermission;
 
   if (
     payload.action !== "submitted" ||
     payload.review?.state?.toLowerCase() !== "changes_requested" ||
     !FACTORY_REVIEW_REPAIRABLE_STATUSES.includes(metadata?.status) ||
-    !isManaged(pullRequest.labels, pullRequest.head.ref, metadata)
+    !isManaged(pullRequest.labels, pullRequest.head.ref, metadata) ||
+    !isTrustedReviewTrigger({ reviewerLogin, reviewerPermission })
   ) {
     return { action: "noop" };
   }

--- a/scripts/route-pr-loop.mjs
+++ b/scripts/route-pr-loop.mjs
@@ -7,15 +7,18 @@ import {
   routeWorkflowRun
 } from "./lib/event-router.mjs";
 import {
+  getCollaboratorPermission,
   findOpenPullRequestByHead,
   getPullRequest
 } from "./lib/github.mjs";
 import { setOutputs } from "./lib/actions-output.mjs";
+import { isTrustedReviewTrigger } from "./lib/event-router.mjs";
 
 export async function routeEvent({
   eventName,
   payload,
   githubClient = {
+    getCollaboratorPermission,
     findOpenPullRequestByHead,
     getPullRequest
   }
@@ -32,7 +35,30 @@ export async function routeEvent({
   }
 
   if (eventName === "pull_request_review") {
-    return routePullRequestReview(payload);
+    const livePullRequest = payload.pull_request?.number
+      ? await githubClient.getPullRequest(payload.pull_request.number)
+      : payload.pull_request;
+    const reviewerLogin = payload.review?.user?.login || "";
+    let reviewerPermission = "";
+
+    if (
+      reviewerLogin &&
+      !isTrustedReviewTrigger({ reviewerLogin }) &&
+      githubClient.getCollaboratorPermission
+    ) {
+      try {
+        reviewerPermission =
+          (await githubClient.getCollaboratorPermission(reviewerLogin))?.permission || "";
+      } catch {
+        reviewerPermission = "";
+      }
+    }
+
+    return routePullRequestReview({
+      ...payload,
+      pull_request: livePullRequest || payload.pull_request,
+      reviewerPermission
+    });
   }
 
   if (eventName === "workflow_run") {

--- a/tests/event-router.test.mjs
+++ b/tests/event-router.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  isTrustedReviewTrigger,
   routePullRequestLabeled,
   routePullRequestReview,
   routeWorkflowRun
@@ -136,10 +137,28 @@ test("routePullRequestLabeled retries implementation for managed PRs already mar
   assert.equal(result.prNumber, 33);
 });
 
-test("routePullRequestReview triggers repair on changes requested", () => {
+test("isTrustedReviewTrigger trusts maintainers and automation actors", () => {
+  assert.equal(isTrustedReviewTrigger({ reviewerPermission: "write" }), true);
+  assert.equal(isTrustedReviewTrigger({ reviewerPermission: "maintain" }), true);
+  assert.equal(isTrustedReviewTrigger({ reviewerPermission: "admin" }), true);
+  assert.equal(
+    isTrustedReviewTrigger({ reviewerLogin: "github-actions[bot]" }),
+    true
+  );
+  assert.equal(isTrustedReviewTrigger({ reviewerLogin: "app/github-actions" }), true);
+  assert.equal(isTrustedReviewTrigger({ reviewerPermission: "read" }), false);
+});
+
+test("routePullRequestReview triggers repair on trusted maintainer changes requested", () => {
   const result = routePullRequestReview({
     action: "submitted",
-    review: { id: 55, state: "changes_requested", body: "Please tighten the tests." },
+    reviewerPermission: "write",
+    review: {
+      id: 55,
+      state: "changes_requested",
+      body: "Please tighten the tests.",
+      user: { login: "briancavalier" }
+    },
     pull_request: {
       number: 33,
       body: managedPrBody("implementing"),
@@ -156,7 +175,8 @@ test("routePullRequestReview triggers repair on changes requested", () => {
 test("routePullRequestReview also handles reviewing status", () => {
   const result = routePullRequestReview({
     action: "submitted",
-    review: { id: 56, state: "CHANGES_REQUESTED" },
+    reviewerPermission: "maintain",
+    review: { id: 56, state: "CHANGES_REQUESTED", user: { login: "maintainer" } },
     pull_request: {
       number: 33,
       body: managedPrBody("reviewing"),
@@ -167,6 +187,47 @@ test("routePullRequestReview also handles reviewing status", () => {
 
   assert.equal(result.action, "repair");
   assert.equal(result.reviewId, 56);
+});
+
+test("routePullRequestReview ignores untrusted public reviewers", () => {
+  const result = routePullRequestReview({
+    action: "submitted",
+    reviewerPermission: "read",
+    review: {
+      id: 57,
+      state: "changes_requested",
+      body: "Force a repair run",
+      user: { login: "random-user" }
+    },
+    pull_request: {
+      number: 33,
+      body: managedPrBody("implementing"),
+      labels: managedLabels(),
+      head: { ref: "factory/12-sample" }
+    }
+  });
+
+  assert.equal(result.action, "noop");
+});
+
+test("routePullRequestReview trusts automation review actors", () => {
+  const result = routePullRequestReview({
+    action: "submitted",
+    review: {
+      id: 58,
+      state: "changes_requested",
+      user: { login: "github-actions[bot]" }
+    },
+    pull_request: {
+      number: 33,
+      body: managedPrBody("reviewing"),
+      labels: managedLabels(),
+      head: { ref: "factory/12-sample" }
+    }
+  });
+
+  assert.equal(result.action, "repair");
+  assert.equal(result.reviewId, 58);
 });
 
 test("routeWorkflowRun routes successful CI to review stage", () => {

--- a/tests/route-pr-loop.test.mjs
+++ b/tests/route-pr-loop.test.mjs
@@ -54,3 +54,102 @@ test("routeEvent uses live pull request state for implement label events", async
 
   assert.equal(route.action, "noop");
 });
+
+test("routeEvent uses live pull request state and collaborator permission for review events", async () => {
+  const payload = {
+    action: "submitted",
+    review: {
+      id: 55,
+      state: "changes_requested",
+      body: "Please tighten the tests.",
+      user: { login: "briancavalier" }
+    },
+    pull_request: {
+      number: 33,
+      body: managedPrBody("plan_ready"),
+      labels: managedLabels(),
+      head: { ref: "factory/12-sample" }
+    }
+  };
+
+  const route = await routeEvent({
+    eventName: "pull_request_review",
+    payload,
+    githubClient: {
+      getPullRequest: async () => ({
+        number: 33,
+        body: managedPrBody("implementing"),
+        labels: managedLabels(),
+        head: { ref: "factory/12-sample" }
+      }),
+      getCollaboratorPermission: async () => ({ permission: "write" }),
+      findOpenPullRequestByHead: async () => null
+    }
+  });
+
+  assert.equal(route.action, "repair");
+  assert.equal(route.reviewId, 55);
+});
+
+test("routeEvent ignores untrusted review triggers", async () => {
+  const payload = {
+    action: "submitted",
+    review: {
+      id: 56,
+      state: "changes_requested",
+      user: { login: "random-user" }
+    },
+    pull_request: {
+      number: 33,
+      body: managedPrBody("implementing"),
+      labels: managedLabels(),
+      head: { ref: "factory/12-sample" }
+    }
+  };
+
+  const route = await routeEvent({
+    eventName: "pull_request_review",
+    payload,
+    githubClient: {
+      getPullRequest: async () => payload.pull_request,
+      getCollaboratorPermission: async () => ({ permission: "read" }),
+      findOpenPullRequestByHead: async () => null
+    }
+  });
+
+  assert.equal(route.action, "noop");
+});
+
+test("routeEvent trusts automation review actors without collaborator lookup", async () => {
+  let collaboratorLookups = 0;
+  const payload = {
+    action: "submitted",
+    review: {
+      id: 57,
+      state: "changes_requested",
+      user: { login: "github-actions[bot]" }
+    },
+    pull_request: {
+      number: 33,
+      body: managedPrBody("reviewing"),
+      labels: managedLabels(),
+      head: { ref: "factory/12-sample" }
+    }
+  };
+
+  const route = await routeEvent({
+    eventName: "pull_request_review",
+    payload,
+    githubClient: {
+      getPullRequest: async () => payload.pull_request,
+      getCollaboratorPermission: async () => {
+        collaboratorLookups += 1;
+        return { permission: "read" };
+      },
+      findOpenPullRequestByHead: async () => null
+    }
+  });
+
+  assert.equal(route.action, "repair");
+  assert.equal(collaboratorLookups, 0);
+});


### PR DESCRIPTION
## Problem Statement
The factory PR loop currently treats any public `changes_requested` review on a managed factory PR as a trusted repair trigger. In a public repository, that means an untrusted reviewer can force billable repair runs and mutate factory PR state without maintainer authorization.

## What Changed
- require trusted reviewer identity before `pull_request_review` can route to `repair`
- fetch the live PR and resolve collaborator permission for human review actors
- explicitly trust the GitHub Actions automation actor so autonomous `REQUEST_CHANGES` reviews still re-enter the repair loop
- add regression coverage for maintainer, public, and automation review paths

## Reviewer Context
This is a security hardening change, not a workflow redesign.

The intended trust model after this PR is:
- human review triggers are accepted only from collaborators with `write`, `maintain`, or `admin`
- autonomous factory reviews created by GitHub Actions remain trusted
- all other `changes_requested` reviews become `noop`

The implementation keeps `pull_request` label routing and `workflow_run` CI routing unchanged.

## What To Verify
- a maintainer-authored `changes_requested` review still routes to `repair`
- a public reviewer no longer triggers repair on a managed factory PR
- GitHub Actions-authored `REQUEST_CHANGES` reviews still trigger repair
- no behavior changed for implement-label or CI-driven review/repair routing

## Validation
- `npm test -- tests/event-router.test.mjs`
- `npm test -- tests/route-pr-loop.test.mjs`