### PR TITLE
Phase 1: reject untrusted factory PR sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Configure these before using the scaffold in a live repository:
 4. Apply the `factory:implement` label to start coding.
 5. Review the ready-for-review PR and merge manually when satisfied.
 
-For public repositories, maintainers cannot sponsor outsider-authored factory issues into execution. Intake now requires both the issue author and the actor applying `factory:start` to be trusted collaborators.
+For public repositories, maintainers cannot sponsor outsider-authored factory issues into execution. Intake now requires both the issue author and the actor applying `factory:start` to be trusted collaborators. Factory automation also ignores fork-backed pull requests entirely, so outsider PRs cannot trigger implement, repair, or review stages.
 
 ## Autonomous review stage
 

--- a/scripts/lib/event-router.mjs
+++ b/scripts/lib/event-router.mjs
@@ -16,6 +16,71 @@ function hasLabel(labels, labelName) {
   return labels.some((label) => label.name === labelName);
 }
 
+function normalizeRepositoryFullName(value) {
+  return `${value || ""}`.trim();
+}
+
+function resolveExpectedRepositoryFullName(payload, pullRequest) {
+  return (
+    normalizeRepositoryFullName(payload?.repositoryFullName) ||
+    normalizeRepositoryFullName(payload?.repository?.full_name) ||
+    normalizeRepositoryFullName(pullRequest?.base?.repo?.full_name)
+  );
+}
+
+function resolveHeadRepositoryContext(pullRequest) {
+  return {
+    fullName: normalizeRepositoryFullName(pullRequest?.head?.repo?.full_name),
+    fork: pullRequest?.head?.repo?.fork === true
+  };
+}
+
+export function validateFactoryRepoTrust(payload, pullRequest) {
+  const expectedRepositoryFullName = resolveExpectedRepositoryFullName(
+    payload,
+    pullRequest
+  );
+  const headRepository = resolveHeadRepositoryContext(pullRequest);
+
+  if (!expectedRepositoryFullName) {
+    return {
+      trusted: false,
+      reason: "missing expected repository metadata"
+    };
+  }
+
+  if (!headRepository.fullName) {
+    return {
+      trusted: false,
+      reason: "missing pull request head repository metadata"
+    };
+  }
+
+  if (headRepository.fork) {
+    return {
+      trusted: false,
+      reason: `fork-backed PR head ${headRepository.fullName}`
+    };
+  }
+
+  if (headRepository.fullName !== expectedRepositoryFullName) {
+    return {
+      trusted: false,
+      reason:
+        `pull request head repo ${headRepository.fullName} does not match expected repository ${expectedRepositoryFullName}`
+    };
+  }
+
+  return {
+    trusted: true,
+    repositoryFullName: expectedRepositoryFullName
+  };
+}
+
+function logRepoTrustNoop(trigger, reason) {
+  console.info(`Ignoring ${trigger}: ${reason}.`);
+}
+
 function isManaged(labels, branchName, metadata) {
   return (
     isFactoryBranch(branchName) &&
@@ -38,6 +103,13 @@ export function isTrustedReviewTrigger({ reviewerLogin, reviewerPermission } = {
 
 export function routePullRequestLabeled(payload) {
   const pullRequest = payload.pull_request;
+  const repoTrust = validateFactoryRepoTrust(payload, pullRequest);
+
+  if (!repoTrust.trusted) {
+    logRepoTrustNoop("factory implement trigger", repoTrust.reason);
+    return { action: "noop" };
+  }
+
   const metadata = extractPrMetadata(pullRequest.body);
 
   if (
@@ -63,6 +135,13 @@ export function routePullRequestLabeled(payload) {
 
 export function routePullRequestReview(payload) {
   const pullRequest = payload.pull_request;
+  const repoTrust = validateFactoryRepoTrust(payload, pullRequest);
+
+  if (!repoTrust.trusted) {
+    logRepoTrustNoop("factory review trigger", repoTrust.reason);
+    return { action: "noop" };
+  }
+
   const metadata = extractPrMetadata(pullRequest.body);
   const reviewerLogin = payload.review?.user?.login || "";
   const reviewerPermission = payload.reviewerPermission;
@@ -98,6 +177,19 @@ export function routePullRequestReview(payload) {
 
 export function routeWorkflowRun({ workflowRun, pullRequest }) {
   if (!pullRequest) {
+    return { action: "noop" };
+  }
+
+  const repoTrust = validateFactoryRepoTrust(
+    {
+      repositoryFullName:
+        workflowRun?.repository?.full_name || pullRequest?.base?.repo?.full_name || ""
+    },
+    pullRequest
+  );
+
+  if (!repoTrust.trusted) {
+    logRepoTrustNoop("factory workflow_run trigger", repoTrust.reason);
     return { action: "noop" };
   }
 

--- a/scripts/route-pr-loop.mjs
+++ b/scripts/route-pr-loop.mjs
@@ -30,6 +30,8 @@ export async function routeEvent({
 
     return routePullRequestLabeled({
       ...payload,
+      repositoryFullName:
+        payload.repository?.full_name || process.env.GITHUB_REPOSITORY || "",
       pull_request: livePullRequest || payload.pull_request
     });
   }
@@ -56,6 +58,8 @@ export async function routeEvent({
 
     return routePullRequestReview({
       ...payload,
+      repositoryFullName:
+        payload.repository?.full_name || process.env.GITHUB_REPOSITORY || "",
       pull_request: livePullRequest || payload.pull_request,
       reviewerPermission
     });
@@ -70,7 +74,13 @@ export async function routeEvent({
         ? await githubClient.findOpenPullRequestByHead(workflowRun.head_branch)
         : null;
 
-    return routeWorkflowRun({ workflowRun, pullRequest });
+    return routeWorkflowRun({
+      workflowRun: {
+        ...workflowRun,
+        repository: payload.repository || workflowRun.repository || null
+      },
+      pullRequest
+    });
   }
 
   return { action: "noop" };

--- a/tests/event-router.test.mjs
+++ b/tests/event-router.test.mjs
@@ -7,7 +7,8 @@ import {
   isTrustedReviewTrigger,
   routePullRequestLabeled,
   routePullRequestReview,
-  routeWorkflowRun
+  routeWorkflowRun,
+  validateFactoryRepoTrust
 } from "../scripts/lib/event-router.mjs";
 import { FACTORY_LABELS } from "../scripts/lib/factory-config.mjs";
 import { renderPrBody } from "../scripts/lib/pr-metadata.mjs";
@@ -35,6 +36,36 @@ function managedLabels(extra = []) {
   return [{ name: FACTORY_LABELS.managed }, ...extra];
 }
 
+function sameRepoHead(overrides = {}) {
+  return {
+    ref: "factory/12-sample",
+    repo: {
+      full_name: "example/repo",
+      fork: false
+    },
+    ...overrides
+  };
+}
+
+function sameRepoBase() {
+  return {
+    repo: {
+      full_name: "example/repo"
+    }
+  };
+}
+
+function basePullRequest(overrides = {}) {
+  return {
+    number: 33,
+    body: managedPrBody(),
+    labels: managedLabels(),
+    head: sameRepoHead(),
+    base: sameRepoBase(),
+    ...overrides
+  };
+}
+
 function makeOverrides(files = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "factory-route-messages-"));
 
@@ -45,16 +76,72 @@ function makeOverrides(files = {}) {
   return dir;
 }
 
+test("validateFactoryRepoTrust accepts same-repo PR heads", () => {
+  const result = validateFactoryRepoTrust(
+    { repositoryFullName: "example/repo" },
+    basePullRequest()
+  );
+
+  assert.equal(result.trusted, true);
+  assert.equal(result.repositoryFullName, "example/repo");
+});
+
+test("validateFactoryRepoTrust rejects fork-backed PR heads", () => {
+  const result = validateFactoryRepoTrust(
+    { repositoryFullName: "example/repo" },
+    basePullRequest({
+      head: sameRepoHead({
+        repo: {
+          full_name: "attacker/repo",
+          fork: true
+        }
+      })
+    })
+  );
+
+  assert.equal(result.trusted, false);
+  assert.match(result.reason, /fork-backed PR head/);
+});
+
+test("validateFactoryRepoTrust rejects head repo mismatches", () => {
+  const result = validateFactoryRepoTrust(
+    { repositoryFullName: "example/repo" },
+    basePullRequest({
+      head: sameRepoHead({
+        repo: {
+          full_name: "other/repo",
+          fork: false
+        }
+      })
+    })
+  );
+
+  assert.equal(result.trusted, false);
+  assert.match(result.reason, /does not match expected repository/);
+});
+
+test("validateFactoryRepoTrust rejects missing head repo metadata", () => {
+  const result = validateFactoryRepoTrust(
+    { repositoryFullName: "example/repo" },
+    basePullRequest({
+      head: {
+        ref: "factory/12-sample"
+      }
+    })
+  );
+
+  assert.equal(result.trusted, false);
+  assert.match(result.reason, /missing pull request head repository metadata/);
+});
+
 test("routePullRequestLabeled starts implementation for approved managed PRs", () => {
   const result = routePullRequestLabeled({
     action: "labeled",
     label: { name: FACTORY_LABELS.implement },
-    pull_request: {
-      number: 33,
-      body: managedPrBody(),
-      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
-      head: { ref: "factory/12-sample" }
-    }
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }])
+    })
   });
 
   assert.equal(result.action, "implement");
@@ -66,12 +153,10 @@ test("routePullRequestLabeled ignores stale implement events when the label is n
   const result = routePullRequestLabeled({
     action: "labeled",
     label: { name: FACTORY_LABELS.implement },
-    pull_request: {
-      number: 33,
-      body: managedPrBody("implementing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
+      body: managedPrBody("implementing")
+    })
   });
 
   assert.equal(result.action, "noop");
@@ -90,8 +175,8 @@ test("routePullRequestLabeled still parses metadata from custom PR body template
   const result = routePullRequestLabeled({
     action: "labeled",
     label: { name: FACTORY_LABELS.implement },
-    pull_request: {
-      number: 33,
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
       body: renderPrBody(
         {
           issueNumber: 12,
@@ -110,9 +195,8 @@ test("routePullRequestLabeled still parses metadata from custom PR body template
         },
         { overridesRoot }
       ),
-      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
-      head: { ref: "factory/12-sample" }
-    }
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }])
+    })
   });
 
   assert.equal(result.action, "implement");
@@ -124,17 +208,68 @@ test("routePullRequestLabeled retries implementation for managed PRs already mar
   const result = routePullRequestLabeled({
     action: "labeled",
     label: { name: FACTORY_LABELS.implement },
-    pull_request: {
-      number: 33,
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
       body: managedPrBody("implementing"),
-      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
-      head: { ref: "factory/12-sample" }
-    }
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }])
+    })
   });
 
   assert.equal(result.action, "implement");
   assert.equal(result.issueNumber, 12);
   assert.equal(result.prNumber, 33);
+});
+
+test("routePullRequestLabeled returns noop for fork-backed PRs", () => {
+  const result = routePullRequestLabeled({
+    action: "labeled",
+    label: { name: FACTORY_LABELS.implement },
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
+      head: sameRepoHead({
+        repo: {
+          full_name: "attacker/repo",
+          fork: true
+        }
+      })
+    })
+  });
+
+  assert.equal(result.action, "noop");
+});
+
+test("routePullRequestLabeled returns noop for same-branch different-repo heads", () => {
+  const result = routePullRequestLabeled({
+    action: "labeled",
+    label: { name: FACTORY_LABELS.implement },
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
+      head: sameRepoHead({
+        repo: {
+          full_name: "other/repo",
+          fork: false
+        }
+      })
+    })
+  });
+
+  assert.equal(result.action, "noop");
+});
+
+test("routePullRequestLabeled returns noop when head repo metadata is missing", () => {
+  const result = routePullRequestLabeled({
+    action: "labeled",
+    label: { name: FACTORY_LABELS.implement },
+    repository: { full_name: "example/repo" },
+    pull_request: basePullRequest({
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
+      head: { ref: "factory/12-sample" }
+    })
+  });
+
+  assert.equal(result.action, "noop");
 });
 
 test("isTrustedReviewTrigger trusts maintainers and automation actors", () => {
@@ -153,18 +288,16 @@ test("routePullRequestReview triggers repair on trusted maintainer changes reque
   const result = routePullRequestReview({
     action: "submitted",
     reviewerPermission: "write",
+    repository: { full_name: "example/repo" },
     review: {
       id: 55,
       state: "changes_requested",
       body: "Please tighten the tests.",
       user: { login: "briancavalier" }
     },
-    pull_request: {
-      number: 33,
-      body: managedPrBody("implementing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pull_request: basePullRequest({
+      body: managedPrBody("implementing")
+    })
   });
 
   assert.equal(result.action, "repair");
@@ -176,13 +309,11 @@ test("routePullRequestReview also handles reviewing status", () => {
   const result = routePullRequestReview({
     action: "submitted",
     reviewerPermission: "maintain",
+    repository: { full_name: "example/repo" },
     review: { id: 56, state: "CHANGES_REQUESTED", user: { login: "maintainer" } },
-    pull_request: {
-      number: 33,
-      body: managedPrBody("reviewing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pull_request: basePullRequest({
+      body: managedPrBody("reviewing")
+    })
   });
 
   assert.equal(result.action, "repair");
@@ -193,18 +324,16 @@ test("routePullRequestReview ignores untrusted public reviewers", () => {
   const result = routePullRequestReview({
     action: "submitted",
     reviewerPermission: "read",
+    repository: { full_name: "example/repo" },
     review: {
       id: 57,
       state: "changes_requested",
       body: "Force a repair run",
       user: { login: "random-user" }
     },
-    pull_request: {
-      number: 33,
-      body: managedPrBody("implementing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pull_request: basePullRequest({
+      body: managedPrBody("implementing")
+    })
   });
 
   assert.equal(result.action, "noop");
@@ -213,21 +342,43 @@ test("routePullRequestReview ignores untrusted public reviewers", () => {
 test("routePullRequestReview trusts automation review actors", () => {
   const result = routePullRequestReview({
     action: "submitted",
+    repository: { full_name: "example/repo" },
     review: {
       id: 58,
       state: "changes_requested",
       user: { login: "github-actions[bot]" }
     },
-    pull_request: {
-      number: 33,
-      body: managedPrBody("reviewing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pull_request: basePullRequest({
+      body: managedPrBody("reviewing")
+    })
   });
 
   assert.equal(result.action, "repair");
   assert.equal(result.reviewId, 58);
+});
+
+test("routePullRequestReview returns noop for repo-mismatched heads", () => {
+  const result = routePullRequestReview({
+    action: "submitted",
+    reviewerPermission: "write",
+    repository: { full_name: "example/repo" },
+    review: {
+      id: 59,
+      state: "changes_requested",
+      user: { login: "maintainer" }
+    },
+    pull_request: basePullRequest({
+      body: managedPrBody("implementing"),
+      head: sameRepoHead({
+        repo: {
+          full_name: "other/repo",
+          fork: false
+        }
+      })
+    })
+  });
+
+  assert.equal(result.action, "noop");
 });
 
 test("routeWorkflowRun routes successful CI to review stage", () => {
@@ -238,14 +389,12 @@ test("routeWorkflowRun routes successful CI to review stage", () => {
       conclusion: "success",
       event: "pull_request",
       head_branch: "factory/12-sample",
-      head_sha: "abc123"
+      head_sha: "abc123",
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("repairing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("repairing")
+    })
   });
 
   assert.equal(result.action, "review");
@@ -259,14 +408,12 @@ test("routeWorkflowRun also reruns review for managed PRs already reviewing", ()
       conclusion: "success",
       event: "pull_request",
       head_branch: "factory/12-sample",
-      head_sha: "def456"
+      head_sha: "def456",
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("reviewing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("reviewing")
+    })
   });
 
   assert.equal(result.action, "review");
@@ -281,14 +428,12 @@ test("routeWorkflowRun ignores CI completions for pending autonomous review comm
       conclusion: "success",
       event: "pull_request",
       head_branch: "factory/12-sample",
-      head_sha: headSha
+      head_sha: headSha,
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("reviewing", 0, { pendingReviewSha: headSha }),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("reviewing", 0, { pendingReviewSha: headSha })
+    })
   });
 
   assert.equal(result.action, "noop");
@@ -302,14 +447,12 @@ test("routeWorkflowRun still triggers review when CI head SHA differs from pendi
       conclusion: "success",
       event: "pull_request",
       head_branch: "factory/12-sample",
-      head_sha: "def456"
+      head_sha: "def456",
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("reviewing", 0, { pendingReviewSha: "abc123" }),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("reviewing", 0, { pendingReviewSha: "abc123" })
+    })
   });
 
   assert.equal(result.action, "review");
@@ -323,14 +466,12 @@ test("routeWorkflowRun ignores push-triggered CI runs for managed PR branches", 
       conclusion: "success",
       event: "push",
       head_branch: "factory/12-sample",
-      head_sha: "abc123"
+      head_sha: "abc123",
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("repairing"),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("repairing")
+    })
   });
 
   assert.equal(result.action, "noop");
@@ -344,14 +485,12 @@ test("routeWorkflowRun ignores already-promoted green SHAs", () => {
       conclusion: "success",
       event: "pull_request",
       head_branch: "factory/12-sample",
-      head_sha: "abc123"
+      head_sha: "abc123",
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("repairing", 0, { lastReadySha: "abc123" }),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("repairing", 0, { lastReadySha: "abc123" })
+    })
   });
 
   assert.equal(result.action, "noop");
@@ -364,15 +503,37 @@ test("routeWorkflowRun blocks after exceeding repair limit", () => {
       name: "CI",
       conclusion: "failure",
       event: "pull_request",
-      head_branch: "factory/12-sample"
+      head_branch: "factory/12-sample",
+      repository: { full_name: "example/repo" }
     },
-    pullRequest: {
-      number: 33,
-      body: managedPrBody("repairing", 3),
-      labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
-    }
+    pullRequest: basePullRequest({
+      body: managedPrBody("repairing", 3)
+    })
   });
 
   assert.equal(result.action, "blocked");
+});
+
+test("routeWorkflowRun returns noop for fork-backed PRs", () => {
+  const result = routeWorkflowRun({
+    workflowRun: {
+      id: 88,
+      name: "CI",
+      conclusion: "success",
+      event: "pull_request",
+      head_branch: "factory/12-sample",
+      head_sha: "abc123",
+      repository: { full_name: "example/repo" }
+    },
+    pullRequest: basePullRequest({
+      head: sameRepoHead({
+        repo: {
+          full_name: "attacker/repo",
+          fork: true
+        }
+      })
+    })
+  });
+
+  assert.equal(result.action, "noop");
 });

--- a/tests/route-pr-loop.test.mjs
+++ b/tests/route-pr-loop.test.mjs
@@ -26,15 +26,36 @@ function managedLabels(extra = []) {
   return [{ name: FACTORY_LABELS.managed }, ...extra];
 }
 
+function sameRepoHead(overrides = {}) {
+  return {
+    ref: "factory/12-sample",
+    repo: {
+      full_name: "example/repo",
+      fork: false
+    },
+    ...overrides
+  };
+}
+
+function sameRepoBase() {
+  return {
+    repo: {
+      full_name: "example/repo"
+    }
+  };
+}
+
 test("routeEvent uses live pull request state for implement label events", async () => {
   const payload = {
     action: "labeled",
     label: { name: FACTORY_LABELS.implement },
+    repository: { full_name: "example/repo" },
     pull_request: {
       number: 33,
       body: managedPrBody(),
       labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
-      head: { ref: "factory/12-sample" }
+      head: sameRepoHead(),
+      base: sameRepoBase()
     }
   };
 
@@ -46,7 +67,8 @@ test("routeEvent uses live pull request state for implement label events", async
         number: 33,
         body: managedPrBody("implementing"),
         labels: managedLabels(),
-        head: { ref: "factory/12-sample" }
+        head: sameRepoHead(),
+        base: sameRepoBase()
       }),
       findOpenPullRequestByHead: async () => null
     }
@@ -58,6 +80,7 @@ test("routeEvent uses live pull request state for implement label events", async
 test("routeEvent uses live pull request state and collaborator permission for review events", async () => {
   const payload = {
     action: "submitted",
+    repository: { full_name: "example/repo" },
     review: {
       id: 55,
       state: "changes_requested",
@@ -68,7 +91,8 @@ test("routeEvent uses live pull request state and collaborator permission for re
       number: 33,
       body: managedPrBody("plan_ready"),
       labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
+      head: sameRepoHead(),
+      base: sameRepoBase()
     }
   };
 
@@ -80,7 +104,8 @@ test("routeEvent uses live pull request state and collaborator permission for re
         number: 33,
         body: managedPrBody("implementing"),
         labels: managedLabels(),
-        head: { ref: "factory/12-sample" }
+        head: sameRepoHead(),
+        base: sameRepoBase()
       }),
       getCollaboratorPermission: async () => ({ permission: "write" }),
       findOpenPullRequestByHead: async () => null
@@ -94,6 +119,7 @@ test("routeEvent uses live pull request state and collaborator permission for re
 test("routeEvent ignores untrusted review triggers", async () => {
   const payload = {
     action: "submitted",
+    repository: { full_name: "example/repo" },
     review: {
       id: 56,
       state: "changes_requested",
@@ -103,7 +129,8 @@ test("routeEvent ignores untrusted review triggers", async () => {
       number: 33,
       body: managedPrBody("implementing"),
       labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
+      head: sameRepoHead(),
+      base: sameRepoBase()
     }
   };
 
@@ -124,6 +151,7 @@ test("routeEvent trusts automation review actors without collaborator lookup", a
   let collaboratorLookups = 0;
   const payload = {
     action: "submitted",
+    repository: { full_name: "example/repo" },
     review: {
       id: 57,
       state: "changes_requested",
@@ -133,7 +161,8 @@ test("routeEvent trusts automation review actors without collaborator lookup", a
       number: 33,
       body: managedPrBody("reviewing"),
       labels: managedLabels(),
-      head: { ref: "factory/12-sample" }
+      head: sameRepoHead(),
+      base: sameRepoBase()
     }
   };
 
@@ -152,4 +181,81 @@ test("routeEvent trusts automation review actors without collaborator lookup", a
 
   assert.equal(route.action, "repair");
   assert.equal(collaboratorLookups, 0);
+});
+
+test("routeEvent downgrades implement to noop when live PR is fork-backed", async () => {
+  const payload = {
+    action: "labeled",
+    label: { name: FACTORY_LABELS.implement },
+    repository: { full_name: "example/repo" },
+    pull_request: {
+      number: 33,
+      body: managedPrBody(),
+      labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
+      head: sameRepoHead(),
+      base: sameRepoBase()
+    }
+  };
+
+  const route = await routeEvent({
+    eventName: "pull_request",
+    payload,
+    githubClient: {
+      getPullRequest: async () => ({
+        number: 33,
+        body: managedPrBody(),
+        labels: managedLabels([{ name: FACTORY_LABELS.implement }]),
+        head: sameRepoHead({
+          repo: {
+            full_name: "attacker/repo",
+            fork: true
+          }
+        }),
+        base: sameRepoBase()
+      })
+    }
+  });
+
+  assert.equal(route.action, "noop");
+});
+
+test("routeEvent downgrades review to noop when live PR head repo mismatches", async () => {
+  const payload = {
+    action: "submitted",
+    repository: { full_name: "example/repo" },
+    review: {
+      id: 58,
+      state: "changes_requested",
+      user: { login: "maintainer" }
+    },
+    pull_request: {
+      number: 33,
+      body: managedPrBody("implementing"),
+      labels: managedLabels(),
+      head: sameRepoHead(),
+      base: sameRepoBase()
+    }
+  };
+
+  const route = await routeEvent({
+    eventName: "pull_request_review",
+    payload,
+    githubClient: {
+      getPullRequest: async () => ({
+        number: 33,
+        body: managedPrBody("implementing"),
+        labels: managedLabels(),
+        head: sameRepoHead({
+          repo: {
+            full_name: "other/repo",
+            fork: false
+          }
+        }),
+        base: sameRepoBase()
+      }),
+      getCollaboratorPermission: async () => ({ permission: "write" })
+    }
+  });
+
+  assert.equal(route.action, "noop");
 });


### PR DESCRIPTION
## Summary
- add a same-repo trust gate for factory pull_request, pull_request_review, and workflow_run routing
- fail closed to noop for fork-backed PRs, head-repo mismatches, and missing head repo metadata
- document that factory automation never runs on fork PRs in this public repo

## Testing
- npm test
