### PR TITLE
Document policy for factory:self-modify

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -7,6 +7,7 @@ This directory contains top-level factory entrypoints used by GitHub Actions.
 - Keep entrypoint scripts thin. They should read env or event inputs, call shared helpers, and emit outputs or side effects with minimal inline logic.
 - Move reusable parsing, routing, metadata, and policy logic into `scripts/lib/` instead of growing entrypoints.
 - Preserve GitHub Actions contracts: env var names, `GITHUB_OUTPUT` behavior, exit semantics, and user-facing log messages.
+- Do not add or automate application of the `factory:self-modify` label. That label must remain a human-applied control for explicit self-modifying runs. If a change would cause workflows, scripts, or agents to add, infer, preserve-by-default, or bulk-apply `factory:self-modify`, stop and require explicit human direction instead.
 
 ## Ownership
 

--- a/scripts/lib/AGENTS.md
+++ b/scripts/lib/AGENTS.md
@@ -18,6 +18,7 @@ This directory contains the shared contracts for factory behavior. Changes here 
 - Treat these modules as shared contracts, not isolated helpers.
 - Prefer pure, testable functions for parsing, routing, metadata rendering, prompt construction, and policy checks.
 - Preserve existing wire formats unless the task explicitly requires a contract change.
+- Treat `factory:self-modify` as a high-trust human control, not an automatable state transition. Do not add shared logic that auto-applies, implicitly infers, defaults, or silently preserves that label on behalf of the factory.
 - Keep `.factory/messages/*.md` as an override surface only. If the template contract changes, update `github-messages.mjs` first and let docs/tests point back to that source of truth.
 - If you change a shared contract, update every dependent caller, workflow assumption, fixture, and test in the same change.
 


### PR DESCRIPTION
## Problem

Phase 3 made factory self-modification explicitly gated, but the repo-level agent guidance did not yet state that factory:self-modify must remain a human-applied control. That leaves room for future agent-authored changes to automate, infer, or preserve the label by default.

## What This PR Changes

- adds an entrypoint-level AGENTS rule forbidding automation that applies factory:self-modify
- adds a shared-contract AGENTS rule treating factory:self-modify as a high-trust human control

## Reviewer Context

Please review this as policy guidance, not runtime enforcement. The goal is to make it explicit that agents must not add, infer, default, or bulk-apply factory:self-modify, and must stop for human direction instead.

## Verification

- docs-only change; no runtime behavior changed