### PR TITLE
Show actual telemetry on initial factory PRs

### DIFF
--- a/scripts/lib/cost-estimation.mjs
+++ b/scripts/lib/cost-estimation.mjs
@@ -528,6 +528,7 @@ export function buildCostMetadataFromSummary(summary) {
   const current = summary?.current || {};
   const thresholds = summary?.thresholds || {};
   const derivedCost = current.derivedCost || {};
+  const actualUsage = current.actualUsage || {};
 
   return {
     costEstimateUsd: Number(derivedCost.totalEstimatedUsd) || 0,
@@ -538,7 +539,22 @@ export function buildCostMetadataFromSummary(summary) {
     costPricingSource: derivedCost.pricingSource || "",
     lastEstimatedStage: current.stage || "",
     lastEstimatedModel: current.model || "",
-    lastStageCostEstimateUsd: Number(derivedCost.stageUsd) || 0
+    lastStageCostEstimateUsd: Number(derivedCost.stageUsd) || 0,
+    actualApiSurface: current.apiSurface || summary?.apiSurface || null,
+    actualStageCostUsd:
+      derivedCost.actualUsd == null ? null : Number(derivedCost.actualUsd),
+    actualInputTokens:
+      actualUsage.inputTokens == null ? null : Number(actualUsage.inputTokens),
+    actualCachedInputTokens:
+      actualUsage.cachedInputTokens == null
+        ? null
+        : Number(actualUsage.cachedInputTokens),
+    actualOutputTokens:
+      actualUsage.outputTokens == null ? null : Number(actualUsage.outputTokens),
+    actualReasoningTokens:
+      actualUsage.reasoningTokens == null
+        ? null
+        : Number(actualUsage.reasoningTokens)
   };
 }
 

--- a/tests/cost-estimation.test.mjs
+++ b/tests/cost-estimation.test.mjs
@@ -188,6 +188,41 @@ test("summarizeIssueUsageEvents preserves actual usage and actual USD", () => {
 test("buildCostMetadataFromSummary extracts PR metadata fields", () => {
   const metadata = buildCostMetadataFromSummary({
     thresholds: { warnUsd: 0.25, highUsd: 1 },
+    apiSurface: "codex-cli",
+    current: {
+      stage: "plan",
+      model: "gpt-5-codex",
+      apiSurface: "codex-cli",
+      actualUsage: {
+        inputTokens: 1596969,
+        cachedInputTokens: 1401216,
+        outputTokens: 12706,
+        reasoningTokens: null
+      },
+      derivedCost: {
+        totalEstimatedUsd: 0.3,
+        band: "medium",
+        emoji: "🟡",
+        pricingSource: "model",
+        stageUsd: 0.3,
+        actualUsd: 2.2984
+      }
+    }
+  });
+
+  assert.equal(metadata.costEstimateBand, "medium");
+  assert.equal(metadata.lastEstimatedModel, "gpt-5-codex");
+  assert.equal(metadata.actualApiSurface, "codex-cli");
+  assert.equal(metadata.actualStageCostUsd, 2.2984);
+  assert.equal(metadata.actualInputTokens, 1596969);
+  assert.equal(metadata.actualCachedInputTokens, 1401216);
+  assert.equal(metadata.actualOutputTokens, 12706);
+  assert.equal(metadata.actualReasoningTokens, null);
+});
+
+test("buildCostMetadataFromSummary leaves actual telemetry null when absent", () => {
+  const metadata = buildCostMetadataFromSummary({
+    thresholds: { warnUsd: 0.25, highUsd: 1 },
     current: {
       stage: "plan",
       model: "gpt-5-codex",
@@ -201,8 +236,12 @@ test("buildCostMetadataFromSummary extracts PR metadata fields", () => {
     }
   });
 
-  assert.equal(metadata.costEstimateBand, "medium");
-  assert.equal(metadata.lastEstimatedModel, "gpt-5-codex");
+  assert.equal(metadata.actualApiSurface, null);
+  assert.equal(metadata.actualStageCostUsd, null);
+  assert.equal(metadata.actualInputTokens, null);
+  assert.equal(metadata.actualCachedInputTokens, null);
+  assert.equal(metadata.actualOutputTokens, null);
+  assert.equal(metadata.actualReasoningTokens, null);
 });
 
 test("buildCostLabelUpdate returns one add label and removes the other bands", () => {

--- a/tests/finalize-plan.test.mjs
+++ b/tests/finalize-plan.test.mjs
@@ -9,6 +9,7 @@ test("finalizePlan removes obsolete cost labels, adds plan-ready labels, and com
   const commentCalls = [];
   const updateCalls = [];
   const createCalls = [];
+  const renderCalls = [];
 
   await finalizePlan({
     env: {
@@ -49,14 +50,23 @@ test("finalizePlan removes obsolete cost labels, adds plan-ready labels, and com
     buildCostMetadataFromSummaryImpl: () => ({
       costEstimateUsd: 0.2,
       costEstimateBand: "medium",
-      costEstimateEmoji: "🟡"
+      costEstimateEmoji: "🟡",
+      actualApiSurface: "codex-cli",
+      actualStageCostUsd: 2.2984,
+      actualInputTokens: 1596969,
+      actualCachedInputTokens: 1401216,
+      actualOutputTokens: 12706,
+      actualReasoningTokens: null
     }),
     buildCostLabelUpdateImpl: () => ({
       addLabel: FACTORY_LABELS.costMedium
     }),
     renderPlanReadyIssueCommentImpl: ({ prNumber }) =>
       `PR #${prNumber} ready; comment /factory implement`,
-    renderPrBodyImpl: ({ prNumber = null }) => `PR body for ${prNumber ?? "draft"}`
+    renderPrBodyImpl: (payload) => {
+      renderCalls.push(payload);
+      return `PR body for ${payload.prNumber ?? "draft"}`;
+    }
   });
 
   assert.equal(createCalls.length, 1);
@@ -82,4 +92,17 @@ test("finalizePlan removes obsolete cost labels, adds plan-ready labels, and com
       body: "PR #85 ready; comment /factory implement"
     }
   ]);
+  assert.equal(renderCalls.length, 2);
+  assert.equal(renderCalls[0].metadata.actualApiSurface, "codex-cli");
+  assert.equal(renderCalls[0].metadata.actualStageCostUsd, 2.2984);
+  assert.equal(renderCalls[0].metadata.actualInputTokens, 1596969);
+  assert.equal(renderCalls[0].metadata.actualCachedInputTokens, 1401216);
+  assert.equal(renderCalls[0].metadata.actualOutputTokens, 12706);
+  assert.equal(renderCalls[0].metadata.actualReasoningTokens, null);
+  assert.equal(renderCalls[1].metadata.actualApiSurface, "codex-cli");
+  assert.equal(renderCalls[1].metadata.actualStageCostUsd, 2.2984);
+  assert.equal(renderCalls[1].metadata.actualInputTokens, 1596969);
+  assert.equal(renderCalls[1].metadata.actualCachedInputTokens, 1401216);
+  assert.equal(renderCalls[1].metadata.actualOutputTokens, 12706);
+  assert.equal(renderCalls[1].metadata.actualReasoningTokens, null);
 });


### PR DESCRIPTION
## Problem Statement
Factory PRs created during the finalize path still omit actual cost and token telemetry even when the plan-stage hybrid run has already persisted that data to `cost-summary.json`. This makes newly created PRs like #122 look estimate-only until a later PR-state update happens.

## Motivation
The dashboard now supports actual telemetry, but the first PR body is still missing it in one common path: initial PR creation during finalize. That leaves operators with inconsistent observability depending on whether the PR existed before the stage finished.

## Approach
- extend `buildCostMetadataFromSummary()` to map current-stage actual telemetry fields out of `cost-summary.json`
- let `finalize-plan.mjs` keep using its existing summary-loading flow; it already merges this metadata before rendering the PR body
- add tests for both metadata extraction and finalize-time propagation into the rendered PR body

## Reviewer Context
This is a follow-up to #121. The bug is not in telemetry collection or rendering; it is in the metadata extraction layer used by `finalize-plan.mjs`. The expected behavioral change is that newly created factory PRs immediately show the `Actual:` cost/token segment when the summary already contains actual telemetry.

## Testing
- `/bin/zsh -lc 'export XDG_STATE_HOME=/tmp/fnm-state; eval "$(fnm env --shell zsh)"; nvm use; npm test -- --test tests/cost-estimation.test.mjs tests/finalize-plan.test.mjs tests/github-messages.test.mjs'`
