### PR TITLE
Extend hybrid Codex exec to implement stage

### DIFF
--- a/.github/workflows/_factory-stage.yml
+++ b/.github/workflows/_factory-stage.yml
@@ -289,9 +289,9 @@ jobs:
       - name: Budget preflight hook
         run: echo "Budget enforcement hook not configured."
 
-      - name: Bootstrap Codex CLI canary
+      - name: Bootstrap Codex CLI hybrid
         id: codex_bootstrap
-        if: inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true'
+        if: (inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true') || (inputs.mode == 'implement' && vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true')
         continue-on-error: true
         uses: openai/codex-action@v1
         with:
@@ -299,9 +299,9 @@ jobs:
           sandbox: workspace-write
           codex-version: 0.114.0
 
-      - name: Verify Codex CLI bootstrap
+      - name: Verify Codex CLI hybrid bootstrap
         id: codex_verify
-        if: inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true' && steps.codex_bootstrap.outcome == 'success'
+        if: ((inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true') || (inputs.mode == 'implement' && vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true')) && steps.codex_bootstrap.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |
@@ -310,19 +310,19 @@ jobs:
           codex --version
           test -d "${CODEX_HOME:-$HOME/.codex}"
 
-          canary_dir="${RUNNER_TEMP}/codex-cli-canary/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ inputs.mode }}"
-          mkdir -p "$canary_dir"
+          telemetry_dir="${RUNNER_TEMP}/codex-cli-telemetry/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ inputs.mode }}"
+          mkdir -p "$telemetry_dir"
 
           {
-            echo "canary_dir=$canary_dir"
-            echo "jsonl_path=$canary_dir/codex-events.jsonl"
-            echo "final_message_path=$canary_dir/final-message.md"
-            echo "actual_usage_path=$canary_dir/actual-usage.json"
+            echo "telemetry_dir=$telemetry_dir"
+            echo "jsonl_path=$telemetry_dir/codex-events.jsonl"
+            echo "final_message_path=$telemetry_dir/final-message.md"
+            echo "actual_usage_path=$telemetry_dir/actual-usage.json"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Execute Codex CLI canary
+      - name: Execute Codex CLI hybrid
         id: codex_cli
-        if: inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true' && steps.codex_verify.outcome == 'success'
+        if: ((inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true') || (inputs.mode == 'implement' && vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true')) && steps.codex_verify.outcome == 'success'
         continue-on-error: true
         shell: bash
         run: |
@@ -338,20 +338,20 @@ jobs:
             < .factory/tmp/prompt.md \
             | tee "${{ steps.codex_verify.outputs.jsonl_path }}"
 
-      - name: Parse Codex CLI telemetry
+      - name: Parse Codex CLI hybrid telemetry
         id: codex_json_telemetry
-        if: inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true' && steps.codex_cli.outcome == 'success'
+        if: ((inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true') || (inputs.mode == 'implement' && vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true')) && steps.codex_cli.outcome == 'success'
         continue-on-error: true
         run: node scripts/parse-codex-json-telemetry.mjs
         env:
           FACTORY_CODEX_JSONL_PATH: ${{ steps.codex_verify.outputs.jsonl_path }}
           FACTORY_CODEX_USAGE_OUTPUT_PATH: ${{ steps.codex_verify.outputs.actual_usage_path }}
 
-      - name: Upload Codex CLI canary artifacts
-        if: always() && inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true'
+      - name: Upload Codex CLI hybrid artifacts
+        if: always() && ((inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true') || (inputs.mode == 'implement' && vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true'))
         uses: actions/upload-artifact@v4
         with:
-          name: codex-cli-canary-${{ github.run_id }}-${{ github.job }}-${{ inputs.mode }}
+          name: codex-cli-telemetry-${{ github.run_id }}-${{ github.job }}-${{ inputs.mode }}
           if-no-files-found: ignore
           path: |
             .factory/tmp/prompt.md
@@ -361,7 +361,7 @@ jobs:
 
       - name: Run Codex
         id: codex
-        if: inputs.mode != 'plan' || vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY != 'true'
+        if: (inputs.mode != 'plan' || vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY != 'true') && (inputs.mode != 'implement' || vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT != 'true')
         continue-on-error: true
         uses: openai/codex-action@v1
         with:
@@ -374,7 +374,7 @@ jobs:
 
       - name: Stop on Codex failure
         id: codex_failure
-        if: steps.codex.outcome == 'failure' || (inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true' && (steps.codex_bootstrap.outcome == 'failure' || steps.codex_verify.outcome == 'failure' || steps.codex_cli.outcome == 'failure' || steps.codex_json_telemetry.outcome == 'failure'))
+        if: steps.codex.outcome == 'failure' || (((inputs.mode == 'plan' && vars.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true') || (inputs.mode == 'implement' && vars.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true')) && (steps.codex_bootstrap.outcome == 'failure' || steps.codex_verify.outcome == 'failure' || steps.codex_cli.outcome == 'failure' || steps.codex_json_telemetry.outcome == 'failure'))
         run: |
           echo "failure_type=stage_setup" >> "$GITHUB_OUTPUT"
           echo "failure_message=Stage setup prerequisites failed: Codex stage execution failed before branch output could be prepared." >> "$GITHUB_OUTPUT"

--- a/tests/factory-config-contracts.test.mjs
+++ b/tests/factory-config-contracts.test.mjs
@@ -260,32 +260,32 @@ test("factory stage workflow pins the Codex CLI to the last known good version",
   assert.match(workflowText, /codex-version:\s*0\.114\.0/);
 });
 
-test("factory stage workflow gates the Codex CLI hybrid canary to plan mode", () => {
+test("factory stage workflow gates the Codex CLI hybrid path by stage-specific flags", () => {
   const workflowText = readWorkflowText("_factory-stage.yml");
 
   assert.match(
     workflowText,
-    /name:\s+Bootstrap Codex CLI canary[\s\S]*if:\s*inputs\.mode == 'plan' && vars\.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true'[\s\S]*uses:\s+openai\/codex-action@v1/
+    /name:\s+Bootstrap Codex CLI hybrid[\s\S]*if:\s*\(inputs\.mode == 'plan' && vars\.FACTORY_ENABLE_CODEX_HYBRID_CANARY == 'true'\) \|\| \(inputs\.mode == 'implement' && vars\.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true'\)[\s\S]*uses:\s+openai\/codex-action@v1/
   );
   assert.match(
     workflowText,
-    /name:\s+Verify Codex CLI bootstrap[\s\S]*which codex[\s\S]*codex --version/
+    /name:\s+Verify Codex CLI hybrid bootstrap[\s\S]*which codex[\s\S]*codex --version/
   );
   assert.match(
     workflowText,
-    /name:\s+Execute Codex CLI canary[\s\S]*codex exec[\s\S]*--output-last-message[\s\S]*--full-auto[\s\S]*--sandbox workspace-write[\s\S]*--json/
+    /name:\s+Execute Codex CLI hybrid[\s\S]*codex exec[\s\S]*--output-last-message[\s\S]*--full-auto[\s\S]*--sandbox workspace-write[\s\S]*--json/
   );
   assert.match(
     workflowText,
-    /name:\s+Parse Codex CLI telemetry[\s\S]*node scripts\/parse-codex-json-telemetry\.mjs/
+    /name:\s+Parse Codex CLI hybrid telemetry[\s\S]*node scripts\/parse-codex-json-telemetry\.mjs/
   );
   assert.match(
     workflowText,
-    /name:\s+Upload Codex CLI canary artifacts[\s\S]*uses:\s+actions\/upload-artifact@v4[\s\S]*\.factory\/tmp\/prompt\.md/
+    /name:\s+Upload Codex CLI hybrid artifacts[\s\S]*uses:\s+actions\/upload-artifact@v4[\s\S]*name:\s*codex-cli-telemetry-\$\{\{\s*github\.run_id\s*\}\}-\$\{\{\s*github\.job\s*\}\}-\$\{\{\s*inputs\.mode\s*\}\}[\s\S]*\.factory\/tmp\/prompt\.md/
   );
   assert.match(
     workflowText,
-    /name:\s+Run Codex[\s\S]*if:\s*inputs\.mode != 'plan' \|\| vars\.FACTORY_ENABLE_CODEX_HYBRID_CANARY != 'true'/
+    /name:\s+Run Codex[\s\S]*if:\s*\(inputs\.mode != 'plan' \|\| vars\.FACTORY_ENABLE_CODEX_HYBRID_CANARY != 'true'\) && \(inputs\.mode != 'implement' \|\| vars\.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT != 'true'\)/
   );
 });
 
@@ -414,6 +414,8 @@ test("factory PR loop blocks implement PRs on stage intervention requests", () =
 test("factory stage workflow records estimated cost only after a successful push", () => {
   const workflowText = readWorkflowText("_factory-stage.yml");
   const estimateIndex = workflowText.indexOf("name: Estimate stage cost");
+  const hybridBootstrapIndex = workflowText.indexOf("name: Bootstrap Codex CLI hybrid");
+  const hybridExecuteIndex = workflowText.indexOf("name: Execute Codex CLI hybrid");
   const codexIndex = workflowText.indexOf("name: Run Codex");
   const prepareIndex = workflowText.indexOf("name: Prepare stage output for push");
   const pushIndex = workflowText.indexOf("name: Push stage output");
@@ -421,6 +423,8 @@ test("factory stage workflow records estimated cost only after a successful push
   const recordIndex = workflowText.indexOf("name: Record cost estimate on pull request");
 
   assert.ok(estimateIndex >= 0);
+  assert.ok(hybridBootstrapIndex > estimateIndex);
+  assert.ok(hybridExecuteIndex > hybridBootstrapIndex);
   assert.ok(codexIndex > estimateIndex);
   assert.ok(prepareIndex > codexIndex);
   assert.ok(pushIndex > prepareIndex);
@@ -436,6 +440,10 @@ test("factory stage workflow records estimated cost only after a successful push
   assert.match(
     workflowText,
     /name:\s+Prepare stage output for push[\s\S]*FACTORY_ENABLE_SELF_MODIFY:\s*\$\{\{\s*vars\.FACTORY_ENABLE_SELF_MODIFY \|\| ''\s*\}\}[\s\S]*FACTORY_COST_SUMMARY_PATH:\s*\$\{\{\s*steps\.cost\.outputs\.cost_summary_path\s*\}\}[\s\S]*FACTORY_STAGE_ACTUAL_USAGE_PATH:\s*\$\{\{\s*steps\.codex_json_telemetry\.outputs\.actual_usage_path\s*\}\}/
+  );
+  assert.match(
+    workflowText,
+    /name:\s+Stop on Codex failure[\s\S]*inputs\.mode == 'implement' && vars\.FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT == 'true'/
   );
   assert.match(
     workflowText,

--- a/tests/prepare-stage-push.test.mjs
+++ b/tests/prepare-stage-push.test.mjs
@@ -140,6 +140,101 @@ test("persistCostSummaryForStage skips implement artifact-only output", () => {
   assert.equal(fs.existsSync(path.join(artifactsPath, "cost-summary.json")), false);
 });
 
+test("persistCostSummaryForStage keeps implement no-op telemetry from becoming success output", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "factory-cost-summary-"));
+  const summaryPath = path.join(tempDir, "estimate.json");
+  const artifactsPath = path.join(tempDir, "artifacts");
+
+  fs.writeFileSync(
+    summaryPath,
+    JSON.stringify(
+      {
+        issueNumber: 55,
+        branch: "factory/55-telemetry",
+        provider: "openai",
+        apiSurface: "codex-action",
+        pricing: {
+          version: "openai-2026-03-19",
+          model: "gpt-5-codex",
+          currency: "USD"
+        },
+        current: {
+          stage: "implement",
+          model: "gpt-5-codex",
+          derivedCost: {
+            stageUsdBeforeCalibration: 0.2,
+            stageUsd: 0.2,
+            pricingSource: "model"
+          }
+        },
+        stages: {
+          implement: {
+            mode: "implement",
+            provider: "openai",
+            apiSurface: "codex-action",
+            model: "gpt-5-codex",
+            promptChars: 4000,
+            estimatedUsageBeforeCalibration: {
+              inputTokens: 1000,
+              cachedInputTokens: 0,
+              outputTokens: 1250,
+              reasoningTokens: null
+            },
+            estimatedUsage: {
+              inputTokens: 1000,
+              cachedInputTokens: 0,
+              outputTokens: 1250,
+              reasoningTokens: null
+            },
+            usageCalibration: {
+              bucket: "openai:stage:implement:gpt-5-codex",
+              sampleSize: 0,
+              generatedAt: "",
+              source: "default",
+              multipliers: {
+                inputTokens: 1,
+                cachedInputTokens: 1,
+                outputTokens: 1
+              }
+            },
+            derivedCost: {
+              stageUsdBeforeCalibration: 0.2,
+              stageUsd: 0.2,
+              pricingSource: "model"
+            }
+          }
+        },
+        thresholds: { warnUsd: 0.25, highUsd: 1 }
+      },
+      null,
+      2
+    )
+  );
+
+  const persistedPath = persistCostSummaryForStage({
+    mode: "implement",
+    artifactsPath,
+    costSummaryPath: summaryPath,
+    worktreeHasChanges: false,
+    telemetryContext: {
+      issueNumber: 55,
+      branch: "factory/55-telemetry",
+      runId: "123456789",
+      runAttempt: "1",
+      apiSurface: "codex-cli",
+      actualUsage: {
+        inputTokens: 321,
+        cachedInputTokens: 111,
+        outputTokens: 77,
+        reasoningTokens: 40
+      }
+    }
+  });
+
+  assert.equal(persistedPath, "");
+  assert.equal(fs.existsSync(path.join(artifactsPath, "cost-summary.json")), false);
+});
+
 test("persistCostSummaryForStage writes a usage event and derived summary when allowed", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "factory-cost-summary-"));
   const originalCwd = process.cwd();


### PR DESCRIPTION
## Problem Statement
The factory's hybrid `openai/codex-action` bootstrap + `codex exec --json` path is currently limited to `plan`. That leaves `implement` without the same structured telemetry and actual-usage persistence, even though the downstream persistence and PR-status plumbing already support it.

## Motivation
We have enough evidence that the hybrid path works on `plan`, and `implement` is the next meaningful rollout boundary. Extending the workflow there allows us to capture real token usage and actual USD for implementation runs while preserving the existing implement-stage control-plane behavior.

## Approach
- widen the hybrid workflow gating so `plan` still uses `FACTORY_ENABLE_CODEX_HYBRID_CANARY` and `implement` uses a new `FACTORY_ENABLE_CODEX_HYBRID_IMPLEMENT` repo variable
- generalize the hybrid workflow steps so they apply to both enabled stages and rename the uploaded artifact to the neutral `codex-cli-telemetry-*` form
- keep `Run Codex` as the fallback for non-enabled stages and keep hybrid failures mapped to `stage_setup`
- add a regression test proving implement no-op runs do not persist telemetry as successful stage output when there are no branch changes

## Reviewer Context
This change is intentionally limited to workflow gating and contract coverage. It does not change `prepare-stage-push` rules, no-op blocking, self-modify safeguards, or telemetry schema; it only allows `implement` to feed the same existing actual-usage path that `plan` already uses.

## Testing
- `/bin/zsh -lc 'export XDG_STATE_HOME=/tmp/fnm-state; eval "$(fnm env --shell zsh)"; nvm use; npm test -- --test tests/factory-config-contracts.test.mjs tests/prepare-stage-push.test.mjs tests/parse-codex-json-telemetry.test.mjs'`
