### PR TITLE
[Factory] Add local replay eval substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,40 @@ Validate the checked-in corpus with:
 node scripts/validate-eval-corpus.mjs
 ```
 
+## Eval substrate
+
+The local replay eval substrate is driven by:
+
+```bash
+node scripts/eval.mjs
+```
+
+The eval harness reads `eval/corpus/` as the task source of truth, then
+replays each selected dev task against the existing durable `.factory/runs/*`
+artifacts and linked `.factory/usage-events/*` telemetry. It does not trigger
+live GitHub workflows or re-run Codex; this is artifact-based evaluation of what
+the factory already produced.
+
+Outputs are written under `eval/runs/<run-id>/`:
+
+- `run.json` — the run manifest for the current eval execution
+- `tasks/<task-id>.json` — one normalized result per selected task
+- `eval-summary.json` — machine-readable aggregate rollup
+- `eval-summary.md` — compact human-readable summary
+
+Useful invocation forms:
+
+```bash
+node scripts/eval.mjs
+node scripts/eval.mjs --task factory-run-55-cost-telemetry-calibration
+node scripts/eval.mjs --output eval/runs/manual-smoke
+```
+
+The result schema includes a `human_audit` block for every task. Issue `#91`
+models this shape now, but does not populate real human judgments yet; required
+tasks currently report `status: "not_recorded"` until follow-up work adds human
+labels.
+
 Prompt precedence tiers for unattended runs are:
 
 1. Stage prompt templates and enforced control-plane logic

--- a/eval/runs/.gitignore
+++ b/eval/runs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/eval.mjs
+++ b/scripts/eval.mjs
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateEvalCorpus } from "./validate-eval-corpus.mjs";
+import { parseEvalCliArgs, runEval, DEFAULT_CORPUS_ROOT } from "./lib/eval-runner.mjs";
+
+export function main(argv = process.argv.slice(2), repoRoot = process.cwd()) {
+  const options = parseEvalCliArgs(argv);
+  validateEvalCorpus(DEFAULT_CORPUS_ROOT, repoRoot);
+
+  const result = runEval({
+    repoRoot,
+    corpusRoot: DEFAULT_CORPUS_ROOT,
+    split: options.split,
+    taskIds: options.taskIds,
+    output: options.output
+  });
+
+  process.stdout.write(
+    `Wrote eval results to ${path.relative(repoRoot, result.outputRoot) || result.outputRoot}\n`
+  );
+
+  return result;
+}
+
+const isDirectExecution =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectExecution) {
+  main();
+}

--- a/scripts/lib/eval-runner.mjs
+++ b/scripts/lib/eval-runner.mjs
@@ -1,0 +1,776 @@
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  validateIndex,
+  validateTaskManifest,
+  validateHoldoutManifest
+} from "../validate-eval-corpus.mjs";
+import { loadCostSummary } from "./cost-estimation.mjs";
+
+export const EVAL_SCHEMA_VERSION = 1;
+export const DEFAULT_CORPUS_ROOT = path.join("eval", "corpus");
+export const DEFAULT_EVAL_RUNS_ROOT = path.join("eval", "runs");
+export const EXECUTION_MODE = "local_replay";
+const TASKS_DIR_NAME = "tasks";
+const HOLDOUT_FILE_NAME = "holdout-manifest.json";
+const INDEX_FILE_NAME = "index.json";
+const REVIEW_DECISIONS = new Set(["pass", "request_changes"]);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function maybeReadJson(filePath) {
+  try {
+    return readJson(filePath);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function fileExists(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function trimString(value) {
+  return `${value ?? ""}`.trim();
+}
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function toSafeRunId(timestamp = new Date()) {
+  return timestamp.toISOString().replace(/[:.]/g, "-");
+}
+
+function sortStrings(values) {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function loadTaskFiles(tasksDir, repoRoot) {
+  return fs
+    .readdirSync(tasksDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((entry) => {
+      const filePath = path.join(tasksDir, entry.name);
+      const manifest = validateTaskManifest(readJson(filePath), repoRoot);
+      return {
+        filePath,
+        manifest
+      };
+    });
+}
+
+export function loadEvalCorpus(corpusRoot = DEFAULT_CORPUS_ROOT, repoRoot = process.cwd()) {
+  const resolvedCorpusRoot = path.resolve(repoRoot, corpusRoot);
+  const index = validateIndex(readJson(path.join(resolvedCorpusRoot, INDEX_FILE_NAME)));
+  const holdout = validateHoldoutManifest(
+    readJson(path.join(resolvedCorpusRoot, HOLDOUT_FILE_NAME))
+  );
+  const taskEntries = loadTaskFiles(path.join(resolvedCorpusRoot, TASKS_DIR_NAME), repoRoot);
+  const tasksById = new Map(taskEntries.map((entry) => [entry.manifest.task_id, entry.manifest]));
+  const manifestTaskIds = sortStrings([...tasksById.keys()]);
+  const declaredTaskIds = sortStrings(index.task_ids);
+
+  if (JSON.stringify(manifestTaskIds) !== JSON.stringify(declaredTaskIds)) {
+    throw new Error("Corpus task manifests do not match eval/corpus/index.json task_ids");
+  }
+
+  return {
+    root: resolvedCorpusRoot,
+    index,
+    holdout,
+    tasksById
+  };
+}
+
+export function selectEvalTasks(corpus, { split = "dev", taskIds = [] } = {}) {
+  if (split !== "dev") {
+    throw new Error(`Unsupported eval split "${split}". Only "dev" is currently runnable.`);
+  }
+
+  const selectedIds = taskIds.length > 0 ? taskIds : corpus.index.splits.dev.task_ids;
+  const missingIds = selectedIds.filter((taskId) => !corpus.tasksById.has(taskId));
+
+  if (missingIds.length > 0) {
+    throw new Error(`Unknown eval task IDs: ${missingIds.join(", ")}`);
+  }
+
+  const tasks = selectedIds.map((taskId) => corpus.tasksById.get(taskId));
+  const nonDevTasks = tasks.filter((task) => task.split !== split);
+
+  if (nonDevTasks.length > 0) {
+    throw new Error(
+      `Requested tasks are not in split "${split}": ${nonDevTasks.map((task) => task.task_id).join(", ")}`
+    );
+  }
+
+  return tasks;
+}
+
+function resolveArtifactAbsolutePaths(task, repoRoot) {
+  return Object.fromEntries(
+    Object.entries(task.artifact_paths).map(([key, relativePath]) => [
+      key,
+      path.resolve(repoRoot, relativePath)
+    ])
+  );
+}
+
+function loadReviewArtifact(reviewJsonPath) {
+  if (!reviewJsonPath || !fileExists(reviewJsonPath)) {
+    return null;
+  }
+
+  return readJson(reviewJsonPath);
+}
+
+function loadCostSummaryArtifact(costSummaryPath) {
+  if (!costSummaryPath || !fileExists(costSummaryPath)) {
+    return null;
+  }
+
+  return loadCostSummary(costSummaryPath);
+}
+
+function loadUsageEvent(repoRoot, sourceEventPath) {
+  const normalized = trimString(sourceEventPath);
+  if (!normalized) {
+    return null;
+  }
+
+  const absolutePath = path.resolve(repoRoot, normalized);
+  if (!fileExists(absolutePath)) {
+    return null;
+  }
+
+  return {
+    path: normalized,
+    payload: readJson(absolutePath)
+  };
+}
+
+function collectStageUsageEvents(repoRoot, costSummary) {
+  const stageUsageEvents = {};
+
+  for (const [stageName, stageData] of Object.entries(costSummary?.stages || {})) {
+    const usageEvent = loadUsageEvent(repoRoot, stageData?.sourceEventPath);
+    if (usageEvent) {
+      stageUsageEvents[stageName] = usageEvent;
+    }
+  }
+
+  return stageUsageEvents;
+}
+
+function summarizeStageOutcome({
+  stageName,
+  task,
+  absoluteArtifactPaths,
+  costSummary,
+  stageUsageEvents
+}) {
+  const costStage = costSummary?.stages?.[stageName] || null;
+  const usageEvent = stageUsageEvents[stageName] || null;
+  let artifactEvidence = [];
+  let present = false;
+  let succeeded = false;
+
+  if (stageName === "plan") {
+    artifactEvidence = [
+      task.artifact_paths.approved_issue,
+      task.artifact_paths.spec,
+      task.artifact_paths.plan,
+      task.artifact_paths.acceptance_tests
+    ].filter(Boolean);
+    present = fileExists(absoluteArtifactPaths.plan);
+    succeeded = present;
+  } else if (stageName === "implement") {
+    artifactEvidence = [task.artifact_paths.cost_summary].filter(Boolean);
+    present = Boolean(costStage);
+    succeeded = usageEvent ? usageEvent.payload.outcome === "succeeded" : present;
+  } else if (stageName === "repair") {
+    artifactEvidence = [task.artifact_paths.repair_log, task.artifact_paths.cost_summary].filter(
+      Boolean
+    );
+    present = Boolean(costStage || fileExists(absoluteArtifactPaths.repair_log || ""));
+    succeeded = usageEvent
+      ? usageEvent.payload.outcome === "succeeded"
+      : fileExists(absoluteArtifactPaths.repair_log || "");
+  } else if (stageName === "review") {
+    artifactEvidence = [task.artifact_paths.review_json, task.artifact_paths.cost_summary].filter(
+      Boolean
+    );
+    present = fileExists(absoluteArtifactPaths.review_json || "") || Boolean(costStage);
+    succeeded = usageEvent
+      ? usageEvent.payload.outcome === "succeeded"
+      : fileExists(absoluteArtifactPaths.review_json || "");
+  }
+
+  return {
+    present,
+    succeeded,
+    artifact_evidence: artifactEvidence,
+    usage_event_paths: usageEvent ? [usageEvent.path] : []
+  };
+}
+
+function countUnmetRequirementChecks(review) {
+  return (review?.requirement_checks || []).filter(
+    (check) => check.status === "partially_satisfied" || check.status === "not_satisfied"
+  ).length;
+}
+
+function summarizeReviewOutcome(review) {
+  if (!review) {
+    return {
+      present: false,
+      decision: null,
+      methodology: null,
+      blocking_findings_count: null,
+      requirement_checks_count: 0,
+      unmet_requirement_checks_count: 0
+    };
+  }
+
+  const decision = REVIEW_DECISIONS.has(review.decision) ? review.decision : trimString(review.decision) || null;
+
+  return {
+    present: true,
+    decision,
+    methodology: trimString(review.methodology) || null,
+    blocking_findings_count:
+      Number.isInteger(review.blocking_findings_count) ? review.blocking_findings_count : null,
+    requirement_checks_count: Array.isArray(review.requirement_checks)
+      ? review.requirement_checks.length
+      : 0,
+    unmet_requirement_checks_count: countUnmetRequirementChecks(review)
+  };
+}
+
+function sumActualStageUsd(costSummary) {
+  return Object.values(costSummary?.stages || {}).reduce((total, stage) => {
+    const actualUsd = stage?.derivedCost?.actualUsd;
+    return total + (typeof actualUsd === "number" ? actualUsd : 0);
+  }, 0);
+}
+
+function countStagesWithActuals(costSummary) {
+  return Object.values(costSummary?.stages || {}).filter(
+    (stage) => typeof stage?.derivedCost?.actualUsd === "number"
+  ).length;
+}
+
+function buildCostSummary(task, costSummary, stageUsageEvents) {
+  const usageEventPaths = uniqueStrings(
+    Object.values(stageUsageEvents).map((entry) => entry.path)
+  );
+
+  return {
+    present: Boolean(costSummary),
+    artifact_path: task.artifact_paths.cost_summary || null,
+    total_estimated_usd: costSummary?.current?.derivedCost?.totalEstimatedUsd ?? null,
+    total_actual_usd: costSummary ? Number(sumActualStageUsd(costSummary).toFixed(4)) : null,
+    tasks_with_actual_stage_costs: costSummary ? countStagesWithActuals(costSummary) : 0,
+    usage_event_paths: usageEventPaths,
+    has_actuals: costSummary ? countStagesWithActuals(costSummary) > 0 : false
+  };
+}
+
+function buildTimingSummary(stageUsageEvents) {
+  const timestamps = Object.values(stageUsageEvents)
+    .map((entry) => trimString(entry.payload.recordedAt))
+    .filter(Boolean)
+    .sort();
+
+  if (timestamps.length === 0) {
+    return {
+      started_at: null,
+      finished_at: null,
+      duration_ms: null
+    };
+  }
+
+  const startedAt = timestamps[0];
+  const finishedAt = timestamps[timestamps.length - 1];
+  const durationMs =
+    timestamps.length > 1
+      ? Math.max(0, new Date(finishedAt).getTime() - new Date(startedAt).getTime())
+      : null;
+
+  return {
+    started_at: startedAt,
+    finished_at: finishedAt,
+    duration_ms: Number.isFinite(durationMs) ? durationMs : null
+  };
+}
+
+function buildHumanAuditSummary(task) {
+  const required = trimString(task.risk_profile).toLowerCase() === "high";
+
+  return {
+    required,
+    status: "not_recorded",
+    reviewer: null,
+    reviewed_at: null,
+    notes: required
+      ? "Human-audited slice is modeled in the schema but not populated by issue #91."
+      : "Human audit not required for this task in issue #91."
+  };
+}
+
+function buildInterventionSummary(task) {
+  return {
+    known: false,
+    count: null,
+    open_failure: false,
+    open_question: false,
+    notes: [
+      `Historical replay task ${task.task_id} does not include canonical serialized PR metadata in the corpus artifacts.`
+    ]
+  };
+}
+
+function buildRepairSummary(task, absoluteArtifactPaths, stageUsageEvents) {
+  const repairLogPath = task.artifact_paths.repair_log || null;
+  const repairLogExists = repairLogPath
+    ? fileExists(absoluteArtifactPaths.repair_log || "")
+    : false;
+  const repairUsageEvent = stageUsageEvents.repair || null;
+
+  return {
+    present: repairLogExists || Boolean(repairUsageEvent),
+    repair_log_present: repairLogExists,
+    repair_log_path: repairLogExists ? repairLogPath : null,
+    evidence_present: repairLogExists || Boolean(repairUsageEvent),
+    usage_event_paths: repairUsageEvent ? [repairUsageEvent.path] : []
+  };
+}
+
+function buildTaskWarnings(stageOutcomes, costSummary, reviewOutcome, interventionSummary) {
+  const warnings = [];
+
+  for (const [stageName, stageOutcome] of Object.entries(stageOutcomes)) {
+    if (stageOutcome.present && stageOutcome.usage_event_paths.length === 0 && stageName !== "plan") {
+      warnings.push(`Stage ${stageName} is present but no linked usage event was available.`);
+    }
+  }
+
+  if (!costSummary.present) {
+    warnings.push("No cost-summary.json artifact was available for this task.");
+  }
+
+  if (!reviewOutcome.present) {
+    warnings.push("No review.json artifact was available for this task.");
+  }
+
+  if (!interventionSummary.known) {
+    warnings.push("Intervention state is not recoverable from the current replay artifact set.");
+  }
+
+  return warnings;
+}
+
+export function synthesizeTaskResult({
+  task,
+  runId,
+  corpusRevision,
+  repoRoot,
+  evaluatedAt = isoNow()
+}) {
+  const absoluteArtifactPaths = resolveArtifactAbsolutePaths(task, repoRoot);
+  const review = loadReviewArtifact(absoluteArtifactPaths.review_json);
+  const costSummary = loadCostSummaryArtifact(absoluteArtifactPaths.cost_summary);
+  const stageUsageEvents = collectStageUsageEvents(repoRoot, costSummary);
+  const stageOutcomes = {
+    plan: summarizeStageOutcome({
+      stageName: "plan",
+      task,
+      absoluteArtifactPaths,
+      costSummary,
+      stageUsageEvents
+    }),
+    implement: summarizeStageOutcome({
+      stageName: "implement",
+      task,
+      absoluteArtifactPaths,
+      costSummary,
+      stageUsageEvents
+    }),
+    repair: summarizeStageOutcome({
+      stageName: "repair",
+      task,
+      absoluteArtifactPaths,
+      costSummary,
+      stageUsageEvents
+    }),
+    review: summarizeStageOutcome({
+      stageName: "review",
+      task,
+      absoluteArtifactPaths,
+      costSummary,
+      stageUsageEvents
+    })
+  };
+  const reviewOutcome = summarizeReviewOutcome(review);
+  const interventionSummary = buildInterventionSummary(task);
+  const repairSummary = buildRepairSummary(task, absoluteArtifactPaths, stageUsageEvents);
+  const costSummaryResult = buildCostSummary(task, costSummary, stageUsageEvents);
+  const timing = buildTimingSummary(stageUsageEvents);
+  const humanAudit = buildHumanAuditSummary(task);
+  const notes = buildTaskWarnings(stageOutcomes, costSummaryResult, reviewOutcome, interventionSummary);
+
+  return {
+    schema_version: EVAL_SCHEMA_VERSION,
+    run_id: runId,
+    task_id: task.task_id,
+    corpus_revision: corpusRevision,
+    evaluated_at: evaluatedAt,
+    source: {
+      mode: EXECUTION_MODE,
+      source_kind: task.source_kind
+    },
+    task: {
+      task_id: task.task_id,
+      issue_number: task.issue_number,
+      title: task.title,
+      summary: task.summary,
+      tags: task.tags,
+      risk_profile: task.risk_profile,
+      control_plane: task.control_plane,
+      comparison_dimensions: task.comparison_dimensions,
+      artifact_paths: task.artifact_paths
+    },
+    stage_outcomes: stageOutcomes,
+    review_outcome: reviewOutcome,
+    intervention_summary: interventionSummary,
+    repair_summary: repairSummary,
+    cost_summary: costSummaryResult,
+    timing,
+    human_audit: humanAudit,
+    notes
+  };
+}
+
+export function summarizeEvalRun({
+  runId,
+  corpusRevision,
+  gitCommit,
+  startedAt,
+  finishedAt,
+  taskResults,
+  selectedTaskIds,
+  warnings = []
+}) {
+  const stageNames = ["plan", "implement", "repair", "review"];
+  const stageSuccessCounts = Object.fromEntries(
+    stageNames.map((stageName) => [
+      stageName,
+      {
+        present: 0,
+        succeeded: 0
+      }
+    ])
+  );
+  const reviewDecisionDistribution = {};
+  let interventionKnownCount = 0;
+  let interventionPresentCount = 0;
+  let repairPresenceCount = 0;
+  let humanAuditRequiredCount = 0;
+  let humanAuditRecordedCount = 0;
+  let tasksWithActualCost = 0;
+  let totalEstimatedUsd = 0;
+  let totalActualUsd = 0;
+  const missingDataWarnings = [...warnings];
+
+  for (const result of taskResults) {
+    for (const stageName of stageNames) {
+      const stageOutcome = result.stage_outcomes[stageName];
+      if (stageOutcome.present) {
+        stageSuccessCounts[stageName].present += 1;
+      }
+      if (stageOutcome.succeeded) {
+        stageSuccessCounts[stageName].succeeded += 1;
+      }
+    }
+
+    const decision = result.review_outcome.decision || "missing";
+    reviewDecisionDistribution[decision] = (reviewDecisionDistribution[decision] || 0) + 1;
+
+    if (result.intervention_summary.known) {
+      interventionKnownCount += 1;
+      if (Number(result.intervention_summary.count || 0) > 0) {
+        interventionPresentCount += 1;
+      }
+    }
+
+    if (result.repair_summary.present) {
+      repairPresenceCount += 1;
+    }
+
+    if (result.human_audit.required) {
+      humanAuditRequiredCount += 1;
+      if (result.human_audit.status !== "not_recorded") {
+        humanAuditRecordedCount += 1;
+      }
+    }
+
+    if (result.cost_summary.has_actuals) {
+      tasksWithActualCost += 1;
+    }
+
+    totalEstimatedUsd += Number(result.cost_summary.total_estimated_usd || 0);
+    totalActualUsd += Number(result.cost_summary.total_actual_usd || 0);
+
+    for (const note of result.notes) {
+      missingDataWarnings.push(`${result.task_id}: ${note}`);
+    }
+  }
+
+  return {
+    schema_version: EVAL_SCHEMA_VERSION,
+    run_id: runId,
+    corpus_revision: corpusRevision,
+    execution_mode: EXECUTION_MODE,
+    git_commit: gitCommit,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    task_count: taskResults.length,
+    selected_task_ids: selectedTaskIds,
+    stage_success_counts: stageSuccessCounts,
+    review_decision_distribution: reviewDecisionDistribution,
+    intervention_rate: interventionKnownCount > 0 ? interventionPresentCount / interventionKnownCount : null,
+    repair_presence_rate: taskResults.length > 0 ? repairPresenceCount / taskResults.length : null,
+    cost_totals: {
+      total_estimated_usd: Number(totalEstimatedUsd.toFixed(4)),
+      total_actual_usd: Number(totalActualUsd.toFixed(4)),
+      tasks_with_actuals: tasksWithActualCost
+    },
+    human_audit: {
+      required_tasks: humanAuditRequiredCount,
+      recorded_tasks: humanAuditRecordedCount,
+      missing_required_tasks: humanAuditRequiredCount - humanAuditRecordedCount
+    },
+    task_warnings: missingDataWarnings
+  };
+}
+
+export function renderEvalSummaryMarkdown(summary, taskResults) {
+  const lines = [
+    "# Eval Summary",
+    "",
+    `- Run ID: \`${summary.run_id}\``,
+    `- Corpus revision: \`${summary.corpus_revision}\``,
+    `- Execution mode: \`${summary.execution_mode}\``,
+    `- Git commit: \`${summary.git_commit}\``,
+    `- Task count: ${summary.task_count}`,
+    ""
+  ];
+
+  lines.push("## Rollup", "");
+  for (const [stageName, counts] of Object.entries(summary.stage_success_counts)) {
+    lines.push(`- ${stageName}: ${counts.succeeded}/${counts.present} succeeded`);
+  }
+  lines.push(
+    `- Review decisions: ${Object.entries(summary.review_decision_distribution)
+      .map(([decision, count]) => `${decision}=${count}`)
+      .join(", ") || "none"}`
+  );
+  lines.push(
+    `- Intervention rate: ${
+      summary.intervention_rate == null ? "unknown" : summary.intervention_rate.toFixed(2)
+    }`
+  );
+  lines.push(`- Repair presence rate: ${summary.repair_presence_rate?.toFixed(2) ?? "0.00"}`);
+  lines.push(
+    `- Cost totals: estimated=$${summary.cost_totals.total_estimated_usd.toFixed(4)} actual=$${summary.cost_totals.total_actual_usd.toFixed(4)} tasks-with-actuals=${summary.cost_totals.tasks_with_actuals}`
+  );
+  lines.push(
+    `- Human audit coverage: required=${summary.human_audit.required_tasks} recorded=${summary.human_audit.recorded_tasks} missing=${summary.human_audit.missing_required_tasks}`
+  );
+  lines.push("", "## Tasks", "");
+
+  for (const result of taskResults) {
+    lines.push(
+      `- \`${result.task_id}\`: review=${result.review_outcome.decision || "missing"}, repair=${result.repair_summary.present ? "present" : "absent"}, actual-costs=${result.cost_summary.has_actuals ? "yes" : "no"}, warnings=${result.notes.length}`
+    );
+  }
+
+  if (summary.task_warnings.length > 0) {
+    lines.push("", "## Warnings", "");
+    for (const warning of summary.task_warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+export function buildRunManifest({
+  runId,
+  corpusRevision,
+  selectedTaskIds,
+  gitCommit,
+  startedAt,
+  finishedAt,
+  warnings = []
+}) {
+  return {
+    schema_version: EVAL_SCHEMA_VERSION,
+    run_id: runId,
+    corpus_revision: corpusRevision,
+    selected_task_ids: selectedTaskIds,
+    execution_mode: EXECUTION_MODE,
+    git_commit: gitCommit,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    warnings
+  };
+}
+
+export function parseEvalCliArgs(argv = []) {
+  const options = {
+    split: "dev",
+    taskIds: [],
+    output: null
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--task") {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error("--task requires a task ID");
+      }
+      options.taskIds.push(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--split") {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error("--split requires a value");
+      }
+      options.split = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error("--output requires a directory path");
+      }
+      options.output = next;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function resolveOutputRoot(outputArg, repoRoot) {
+  return outputArg
+    ? path.resolve(repoRoot, outputArg)
+    : path.resolve(repoRoot, DEFAULT_EVAL_RUNS_ROOT, toSafeRunId());
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+export function getGitCommit(repoRoot = process.cwd()) {
+  return execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  }).trim();
+}
+
+export function runEval({
+  repoRoot = process.cwd(),
+  corpusRoot = DEFAULT_CORPUS_ROOT,
+  split = "dev",
+  taskIds = [],
+  output = null,
+  now = () => new Date(),
+  getGitCommitFn = getGitCommit
+} = {}) {
+  const startedAt = now().toISOString();
+  const runId = output ? path.basename(path.resolve(repoRoot, output)) : toSafeRunId(now());
+  const corpus = loadEvalCorpus(corpusRoot, repoRoot);
+  const tasks = selectEvalTasks(corpus, { split, taskIds });
+  const selectedTaskIds = tasks.map((task) => task.task_id);
+  const outputRoot = output
+    ? path.resolve(repoRoot, output)
+    : path.resolve(repoRoot, DEFAULT_EVAL_RUNS_ROOT, runId);
+  const gitCommit = getGitCommitFn(repoRoot);
+  const taskResults = tasks.map((task) =>
+    synthesizeTaskResult({
+      task,
+      runId,
+      corpusRevision: corpus.index.corpus_revision,
+      repoRoot,
+      evaluatedAt: startedAt
+    })
+  );
+  const finishedAt = now().toISOString();
+  const summary = summarizeEvalRun({
+    runId,
+    corpusRevision: corpus.index.corpus_revision,
+    gitCommit,
+    startedAt,
+    finishedAt,
+    taskResults,
+    selectedTaskIds,
+    warnings: []
+  });
+  const runManifest = buildRunManifest({
+    runId,
+    corpusRevision: corpus.index.corpus_revision,
+    selectedTaskIds,
+    gitCommit,
+    startedAt,
+    finishedAt,
+    warnings: summary.task_warnings
+  });
+
+  writeJson(path.join(outputRoot, "run.json"), runManifest);
+  for (const result of taskResults) {
+    writeJson(path.join(outputRoot, "tasks", `${result.task_id}.json`), result);
+  }
+  writeJson(path.join(outputRoot, "eval-summary.json"), summary);
+  fs.writeFileSync(
+    path.join(outputRoot, "eval-summary.md"),
+    renderEvalSummaryMarkdown(summary, taskResults)
+  );
+
+  return {
+    outputRoot,
+    runManifest,
+    summary,
+    taskResults
+  };
+}

--- a/scripts/lib/eval-runner.mjs
+++ b/scripts/lib/eval-runner.mjs
@@ -166,13 +166,50 @@ function loadUsageEvent(repoRoot, sourceEventPath) {
   };
 }
 
+function selectLatestTelemetryEntriesByStage(costSummary) {
+  const latestByStage = new Map();
+
+  for (const telemetryEntry of costSummary?.telemetry || []) {
+    const stageName = trimString(telemetryEntry?.stage);
+    if (!stageName) {
+      continue;
+    }
+
+    const recordedAt = trimString(telemetryEntry?.recordedAt);
+    const existing = latestByStage.get(stageName);
+
+    if (!existing) {
+      latestByStage.set(stageName, telemetryEntry);
+      continue;
+    }
+
+    const existingRecordedAt = trimString(existing.recordedAt);
+    if (!existingRecordedAt || (recordedAt && recordedAt > existingRecordedAt)) {
+      latestByStage.set(stageName, telemetryEntry);
+    }
+  }
+
+  return latestByStage;
+}
+
 function collectStageUsageEvents(repoRoot, costSummary) {
   const stageUsageEvents = {};
+  const latestTelemetryByStage = selectLatestTelemetryEntriesByStage(costSummary);
 
   for (const [stageName, stageData] of Object.entries(costSummary?.stages || {})) {
     const usageEvent = loadUsageEvent(repoRoot, stageData?.sourceEventPath);
     if (usageEvent) {
       stageUsageEvents[stageName] = usageEvent;
+      continue;
+    }
+
+    const telemetryEntry = latestTelemetryByStage.get(stageName);
+    if (telemetryEntry) {
+      stageUsageEvents[stageName] = {
+        path: null,
+        payload: telemetryEntry,
+        source: "cost_summary.telemetry"
+      };
     }
   }
 
@@ -227,7 +264,7 @@ function summarizeStageOutcome({
     present,
     succeeded,
     artifact_evidence: artifactEvidence,
-    usage_event_paths: usageEvent ? [usageEvent.path] : []
+    usage_event_paths: usageEvent?.path ? [usageEvent.path] : []
   };
 }
 
@@ -359,15 +396,21 @@ function buildRepairSummary(task, absoluteArtifactPaths, stageUsageEvents) {
     repair_log_present: repairLogExists,
     repair_log_path: repairLogExists ? repairLogPath : null,
     evidence_present: repairLogExists || Boolean(repairUsageEvent),
-    usage_event_paths: repairUsageEvent ? [repairUsageEvent.path] : []
+    usage_event_paths: repairUsageEvent?.path ? [repairUsageEvent.path] : []
   };
 }
 
-function buildTaskWarnings(stageOutcomes, costSummary, reviewOutcome, interventionSummary) {
+function buildTaskWarnings(
+  stageOutcomes,
+  stageUsageEvents,
+  costSummary,
+  reviewOutcome,
+  interventionSummary
+) {
   const warnings = [];
 
   for (const [stageName, stageOutcome] of Object.entries(stageOutcomes)) {
-    if (stageOutcome.present && stageOutcome.usage_event_paths.length === 0 && stageName !== "plan") {
+    if (stageOutcome.present && !stageUsageEvents[stageName] && stageName !== "plan") {
       warnings.push(`Stage ${stageName} is present but no linked usage event was available.`);
     }
   }
@@ -434,7 +477,13 @@ export function synthesizeTaskResult({
   const costSummaryResult = buildCostSummary(task, costSummary, stageUsageEvents);
   const timing = buildTimingSummary(stageUsageEvents);
   const humanAudit = buildHumanAuditSummary(task);
-  const notes = buildTaskWarnings(stageOutcomes, costSummaryResult, reviewOutcome, interventionSummary);
+  const notes = buildTaskWarnings(
+    stageOutcomes,
+    stageUsageEvents,
+    costSummaryResult,
+    reviewOutcome,
+    interventionSummary
+  );
 
   return {
     schema_version: EVAL_SCHEMA_VERSION,
@@ -702,6 +751,13 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
 }
 
+function resetTaskResultsDir(outputRoot) {
+  fs.rmSync(path.join(outputRoot, "tasks"), {
+    recursive: true,
+    force: true
+  });
+}
+
 export function getGitCommit(repoRoot = process.cwd()) {
   return execFileSync("git", ["rev-parse", "HEAD"], {
     cwd: repoRoot,
@@ -757,6 +813,7 @@ export function runEval({
     warnings: summary.task_warnings
   });
 
+  resetTaskResultsDir(outputRoot);
   writeJson(path.join(outputRoot, "run.json"), runManifest);
   for (const result of taskResults) {
     writeJson(path.join(outputRoot, "tasks", `${result.task_id}.json`), result);

--- a/tests/eval-cli.test.mjs
+++ b/tests/eval-cli.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { main as evalMain } from "../scripts/eval.mjs";
+
+const REPO_ROOT = path.resolve(path.join(import.meta.dirname, ".."));
+
+function fileExists(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test("eval CLI runs against the checked-in corpus with a task filter", () => {
+  const tempOutput = fs.mkdtempSync(path.join(os.tmpdir(), "eval-cli-"));
+  const outputDir = path.join(tempOutput, "manual-smoke");
+  const writes = [];
+  const originalWrite = process.stdout.write;
+
+  try {
+    process.stdout.write = (chunk) => {
+      writes.push(String(chunk));
+      return true;
+    };
+
+    const result = evalMain(
+      [
+        "--task",
+        "factory-run-55-cost-telemetry-calibration",
+        "--output",
+        outputDir
+      ],
+      REPO_ROOT
+    );
+
+    assert.equal(result.summary.task_count, 1);
+    assert.equal(
+      fileExists(path.join(outputDir, "tasks", "factory-run-55-cost-telemetry-calibration.json")),
+      true
+    );
+    assert.match(writes.join(""), /Wrote eval results to/);
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+});
+
+test("eval CLI rejects invalid task IDs", () => {
+  assert.throws(
+    () => evalMain(["--task", "does-not-exist"], REPO_ROOT),
+    /Unknown eval task IDs/
+  );
+});
+
+test("eval CLI propagates invalid corpus failures", () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "eval-cli-invalid-"));
+  fs.mkdirSync(path.join(repoRoot, "eval", "corpus"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "eval", "corpus", "index.json"), "{}\n");
+  fs.writeFileSync(
+    path.join(repoRoot, "eval", "corpus", "holdout-manifest.json"),
+    JSON.stringify({ schema_version: 1, holdout_revision: 1, entries: [] })
+  );
+  fs.mkdirSync(path.join(repoRoot, "eval", "corpus", "tasks"), { recursive: true });
+
+  assert.throws(() => evalMain([], repoRoot), /index\.json schema_version must be 1/);
+});

--- a/tests/eval-runner.test.mjs
+++ b/tests/eval-runner.test.mjs
@@ -14,16 +14,20 @@ import {
 
 const REPO_ROOT = path.resolve(path.join(import.meta.dirname, ".."));
 
-function makeTempRepoFixture() {
+function makeTempRepoFixture({ telemetryOnly = false, extraTask = false } = {}) {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "eval-runner-"));
   const corpusRoot = path.join(repoRoot, "eval", "corpus");
   const tasksDir = path.join(corpusRoot, "tasks");
   const runDir = path.join(repoRoot, ".factory", "runs", "1");
+  const secondRunDir = path.join(repoRoot, ".factory", "runs", "2");
   const usageDir = path.join(repoRoot, ".factory", "usage-events", "2026-04-06");
 
   fs.mkdirSync(runDir, { recursive: true });
   fs.mkdirSync(tasksDir, { recursive: true });
   fs.mkdirSync(usageDir, { recursive: true });
+  if (extraTask) {
+    fs.mkdirSync(secondRunDir, { recursive: true });
+  }
 
   fs.writeFileSync(path.join(runDir, "approved-issue.md"), "# Approved issue\n");
   fs.writeFileSync(path.join(runDir, "spec.md"), "# Spec\n");
@@ -89,7 +93,6 @@ function makeTempRepoFixture() {
             provider: "openai",
             apiSurface: "codex-action",
             model: "gpt-5-codex",
-            sourceEventPath: ".factory/usage-events/2026-04-06/run-1-1-stage-implement.json",
             derivedCost: {
               stageUsd: 0.75,
               actualUsd: 0.75
@@ -100,18 +103,95 @@ function makeTempRepoFixture() {
             provider: "openai",
             apiSurface: "codex-action",
             model: "gpt-5-mini",
-            sourceEventPath: ".factory/usage-events/2026-04-06/run-1-1-stage-review.json",
             derivedCost: {
               stageUsd: 0.5,
               actualUsd: null
             }
           }
-        }
+        },
+        telemetry: [
+          {
+            stage: "implement",
+            outcome: "succeeded",
+            recordedAt: "2026-04-06T00:00:00Z"
+          },
+          {
+            stage: "review",
+            outcome: "succeeded",
+            recordedAt: "2026-04-06T00:10:00Z"
+          }
+        ]
       },
       null,
       2
     )
   );
+
+  if (!telemetryOnly) {
+    fs.writeFileSync(
+      path.join(runDir, "cost-summary.json"),
+      JSON.stringify(
+        {
+          estimated: true,
+          provider: "openai",
+          apiSurface: "codex-action",
+          pricing: {
+            version: "openai-2026-03-19",
+            model: "gpt-5-codex",
+            currency: "USD"
+          },
+          current: {
+            stage: "review",
+            derivedCost: {
+              totalEstimatedUsd: 1.25
+            }
+          },
+          thresholds: {
+            warnUsd: 0.25,
+            highUsd: 1
+          },
+          stages: {
+            implement: {
+              mode: "implement",
+              provider: "openai",
+              apiSurface: "codex-action",
+              model: "gpt-5-codex",
+              sourceEventPath: ".factory/usage-events/2026-04-06/run-1-1-stage-implement.json",
+              derivedCost: {
+                stageUsd: 0.75,
+                actualUsd: 0.75
+              }
+            },
+            review: {
+              mode: "review",
+              provider: "openai",
+              apiSurface: "codex-action",
+              model: "gpt-5-mini",
+              sourceEventPath: ".factory/usage-events/2026-04-06/run-1-1-stage-review.json",
+              derivedCost: {
+                stageUsd: 0.5,
+                actualUsd: null
+              }
+            }
+          },
+          telemetry: [
+            {
+              stage: "implement",
+              outcome: "succeeded",
+              recordedAt: "2026-04-06T00:00:00Z"
+            },
+            {
+              stage: "review",
+              outcome: "succeeded",
+              recordedAt: "2026-04-06T00:10:00Z"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+  }
 
   fs.writeFileSync(
     path.join(usageDir, "run-1-1-stage-implement.json"),
@@ -149,14 +229,14 @@ function makeTempRepoFixture() {
         updated_at: "2026-04-06T00:00:00Z",
         splits: {
           dev: {
-            task_ids: ["task-1"]
+            task_ids: extraTask ? ["task-1", "task-2"] : ["task-1"]
           },
           holdout: {
             task_ids: ["holdout-1"],
             note: "Holdout is external."
           }
         },
-        task_ids: ["task-1"],
+        task_ids: extraTask ? ["task-1", "task-2"] : ["task-1"],
         holdout_ids: ["holdout-1"],
         notes: ["Sample corpus"]
       },
@@ -217,6 +297,91 @@ function makeTempRepoFixture() {
       2
     )
   );
+
+  if (extraTask) {
+    fs.writeFileSync(path.join(secondRunDir, "approved-issue.md"), "# Approved issue 2\n");
+    fs.writeFileSync(path.join(secondRunDir, "spec.md"), "# Spec 2\n");
+    fs.writeFileSync(path.join(secondRunDir, "plan.md"), "# Plan 2\n");
+    fs.writeFileSync(path.join(secondRunDir, "acceptance-tests.md"), "# Acceptance 2\n");
+    fs.writeFileSync(
+      path.join(secondRunDir, "review.json"),
+      JSON.stringify(
+        {
+          methodology: "default",
+          decision: "pass",
+          blocking_findings_count: 0,
+          requirement_checks: []
+        },
+        null,
+        2
+      )
+    );
+    fs.writeFileSync(
+      path.join(secondRunDir, "cost-summary.json"),
+      JSON.stringify(
+        {
+          estimated: true,
+          provider: "openai",
+          apiSurface: "codex-action",
+          pricing: {
+            version: "openai-2026-03-19",
+            model: "gpt-5-mini",
+            currency: "USD"
+          },
+          current: {
+            stage: "review",
+            derivedCost: {
+              totalEstimatedUsd: 0.5
+            }
+          },
+          stages: {
+            review: {
+              mode: "review",
+              provider: "openai",
+              apiSurface: "codex-action",
+              model: "gpt-5-mini",
+              derivedCost: {
+                stageUsd: 0.5,
+                actualUsd: null
+              }
+            }
+          }
+        },
+        null,
+        2
+      )
+    );
+    fs.writeFileSync(
+      path.join(tasksDir, "task-2.json"),
+      JSON.stringify(
+        {
+          task_id: "task-2",
+          split: "dev",
+          status: "active",
+          source_kind: "replayed_factory_run",
+          issue_number: 2,
+          title: "Second task",
+          summary: "Second task summary",
+          artifact_paths: {
+            approved_issue: ".factory/runs/2/approved-issue.md",
+            spec: ".factory/runs/2/spec.md",
+            plan: ".factory/runs/2/plan.md",
+            acceptance_tests: ".factory/runs/2/acceptance-tests.md",
+            review_json: ".factory/runs/2/review.json",
+            cost_summary: ".factory/runs/2/cost-summary.json"
+          },
+          tags: ["secondary"],
+          risk_profile: "medium",
+          control_plane: false,
+          expected_evidence: ["evidence"],
+          comparison_dimensions: ["stage_completion"],
+          curator_notes: "Secondary task"
+        },
+        null,
+        2
+      )
+    );
+  }
 
   fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
   fs.writeFileSync(path.join(repoRoot, ".git", "HEAD"), "ref: refs/heads/main\n");
@@ -292,6 +457,33 @@ test("synthesizeTaskResult derives stage, review, cost, timing, and human audit 
   assert.equal(result.intervention_summary.known, false);
 });
 
+test("synthesizeTaskResult falls back to normalized cost-summary telemetry when event files are not linked", () => {
+  const repoRoot = makeTempRepoFixture({ telemetryOnly: true });
+  const corpus = loadEvalCorpus(path.join("eval", "corpus"), repoRoot);
+  const task = selectEvalTasks(corpus)[0];
+  const result = synthesizeTaskResult({
+    task,
+    runId: "run-telemetry-only",
+    corpusRevision: corpus.index.corpus_revision,
+    repoRoot,
+    evaluatedAt: "2026-04-06T00:15:00Z"
+  });
+
+  assert.equal(result.stage_outcomes.implement.succeeded, true);
+  assert.equal(result.stage_outcomes.implement.usage_event_paths.length, 0);
+  assert.equal(result.stage_outcomes.review.succeeded, true);
+  assert.equal(result.timing.started_at, "2026-04-06T00:00:00Z");
+  assert.equal(result.timing.duration_ms, 600000);
+  assert.equal(
+    result.notes.some((note) => /Stage implement is present but no linked usage event was available/i.test(note)),
+    false
+  );
+  assert.equal(
+    result.notes.some((note) => /Stage review is present but no linked usage event was available/i.test(note)),
+    false
+  );
+});
+
 test("summarizeEvalRun aggregates multiple task results", () => {
   const taskResults = [
     {
@@ -365,6 +557,29 @@ test("runEval writes task results and aggregate outputs to the requested output 
   assert.equal(fileExists(path.join(outputDir, "eval-summary.json")), true);
   assert.equal(fileExists(path.join(outputDir, "eval-summary.md")), true);
   assert.equal(result.summary.task_count, 1);
+});
+
+test("runEval clears stale task results when reusing an output directory", () => {
+  const repoRoot = makeTempRepoFixture({ extraTask: true });
+  const outputDir = path.join(repoRoot, "eval", "runs", "manual-smoke");
+
+  runEval({
+    repoRoot,
+    output: outputDir,
+    now: () => new Date("2026-04-06T00:15:00Z"),
+    getGitCommitFn: () => "fixture-commit"
+  });
+
+  runEval({
+    repoRoot,
+    taskIds: ["task-1"],
+    output: outputDir,
+    now: () => new Date("2026-04-06T00:20:00Z"),
+    getGitCommitFn: () => "fixture-commit"
+  });
+
+  assert.equal(fileExists(path.join(outputDir, "tasks", "task-1.json")), true);
+  assert.equal(fileExists(path.join(outputDir, "tasks", "task-2.json")), false);
 });
 
 function fileExists(filePath) {

--- a/tests/eval-runner.test.mjs
+++ b/tests/eval-runner.test.mjs
@@ -1,0 +1,377 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  loadEvalCorpus,
+  selectEvalTasks,
+  synthesizeTaskResult,
+  summarizeEvalRun,
+  parseEvalCliArgs,
+  runEval
+} from "../scripts/lib/eval-runner.mjs";
+
+const REPO_ROOT = path.resolve(path.join(import.meta.dirname, ".."));
+
+function makeTempRepoFixture() {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "eval-runner-"));
+  const corpusRoot = path.join(repoRoot, "eval", "corpus");
+  const tasksDir = path.join(corpusRoot, "tasks");
+  const runDir = path.join(repoRoot, ".factory", "runs", "1");
+  const usageDir = path.join(repoRoot, ".factory", "usage-events", "2026-04-06");
+
+  fs.mkdirSync(runDir, { recursive: true });
+  fs.mkdirSync(tasksDir, { recursive: true });
+  fs.mkdirSync(usageDir, { recursive: true });
+
+  fs.writeFileSync(path.join(runDir, "approved-issue.md"), "# Approved issue\n");
+  fs.writeFileSync(path.join(runDir, "spec.md"), "# Spec\n");
+  fs.writeFileSync(path.join(runDir, "plan.md"), "# Plan\n");
+  fs.writeFileSync(path.join(runDir, "acceptance-tests.md"), "# Acceptance\n");
+  fs.writeFileSync(path.join(runDir, "repair-log.md"), "# Repair\n");
+  fs.writeFileSync(
+    path.join(runDir, "review.json"),
+    JSON.stringify(
+      {
+        methodology: "default",
+        decision: "request_changes",
+        summary: "Needs a small fix.",
+        blocking_findings_count: 1,
+        requirement_checks: [
+          {
+            type: "acceptance_criterion",
+            requirement: "A thing works.",
+            status: "not_satisfied",
+            evidence: ["tests/sample.test.mjs"]
+          }
+        ],
+        findings: [
+          {
+            level: "blocking",
+            title: "Fix needed",
+            details: "Observed a failure.",
+            scope: "tests",
+            recommendation: "Fix the issue."
+          }
+        ]
+      },
+      null,
+      2
+    )
+  );
+
+  fs.writeFileSync(
+    path.join(runDir, "cost-summary.json"),
+    JSON.stringify(
+      {
+        estimated: true,
+        provider: "openai",
+        apiSurface: "codex-action",
+        pricing: {
+          version: "openai-2026-03-19",
+          model: "gpt-5-codex",
+          currency: "USD"
+        },
+        current: {
+          stage: "review",
+          derivedCost: {
+            totalEstimatedUsd: 1.25
+          }
+        },
+        thresholds: {
+          warnUsd: 0.25,
+          highUsd: 1
+        },
+        stages: {
+          implement: {
+            mode: "implement",
+            provider: "openai",
+            apiSurface: "codex-action",
+            model: "gpt-5-codex",
+            sourceEventPath: ".factory/usage-events/2026-04-06/run-1-1-stage-implement.json",
+            derivedCost: {
+              stageUsd: 0.75,
+              actualUsd: 0.75
+            }
+          },
+          review: {
+            mode: "review",
+            provider: "openai",
+            apiSurface: "codex-action",
+            model: "gpt-5-mini",
+            sourceEventPath: ".factory/usage-events/2026-04-06/run-1-1-stage-review.json",
+            derivedCost: {
+              stageUsd: 0.5,
+              actualUsd: null
+            }
+          }
+        }
+      },
+      null,
+      2
+    )
+  );
+
+  fs.writeFileSync(
+    path.join(usageDir, "run-1-1-stage-implement.json"),
+    JSON.stringify(
+      {
+        category: "stage",
+        stage: "implement",
+        outcome: "succeeded",
+        recordedAt: "2026-04-06T00:00:00Z"
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(
+    path.join(usageDir, "run-1-1-stage-review.json"),
+    JSON.stringify(
+      {
+        category: "stage",
+        stage: "review",
+        outcome: "succeeded",
+        recordedAt: "2026-04-06T00:10:00Z"
+      },
+      null,
+      2
+    )
+  );
+
+  fs.writeFileSync(
+    path.join(corpusRoot, "index.json"),
+    JSON.stringify(
+      {
+        schema_version: 1,
+        corpus_revision: 3,
+        updated_at: "2026-04-06T00:00:00Z",
+        splits: {
+          dev: {
+            task_ids: ["task-1"]
+          },
+          holdout: {
+            task_ids: ["holdout-1"],
+            note: "Holdout is external."
+          }
+        },
+        task_ids: ["task-1"],
+        holdout_ids: ["holdout-1"],
+        notes: ["Sample corpus"]
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(
+    path.join(corpusRoot, "holdout-manifest.json"),
+    JSON.stringify(
+      {
+        schema_version: 1,
+        holdout_revision: 1,
+        entries: [
+          {
+            task_id: "holdout-1",
+            status: "holdout_external",
+            provenance: "Private",
+            owner: "factory-maintainers",
+            last_reviewed_at: "2026-04-06T00:00:00Z",
+            notes: "No task contents",
+            external_storage_reference: "private-holdout://sample/1"
+          }
+        ]
+      },
+      null,
+      2
+    )
+  );
+  fs.writeFileSync(
+    path.join(tasksDir, "task-1.json"),
+    JSON.stringify(
+      {
+        task_id: "task-1",
+        split: "dev",
+        status: "active",
+        source_kind: "replayed_factory_run",
+        issue_number: 1,
+        title: "Sample task",
+        summary: "Task summary",
+        artifact_paths: {
+          approved_issue: ".factory/runs/1/approved-issue.md",
+          spec: ".factory/runs/1/spec.md",
+          plan: ".factory/runs/1/plan.md",
+          acceptance_tests: ".factory/runs/1/acceptance-tests.md",
+          repair_log: ".factory/runs/1/repair-log.md",
+          review_json: ".factory/runs/1/review.json",
+          cost_summary: ".factory/runs/1/cost-summary.json"
+        },
+        tags: ["sample"],
+        risk_profile: "high",
+        control_plane: true,
+        expected_evidence: ["evidence"],
+        comparison_dimensions: ["stage_completion"],
+        curator_notes: "Sample notes"
+      },
+      null,
+      2
+    )
+  );
+
+  fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, ".git", "HEAD"), "ref: refs/heads/main\n");
+
+  return repoRoot;
+}
+
+test("loadEvalCorpus loads the checked-in corpus", () => {
+  const corpus = loadEvalCorpus(path.join("eval", "corpus"), REPO_ROOT);
+
+  assert.equal(corpus.index.corpus_revision, 1);
+  assert.equal(corpus.tasksById.size, 4);
+});
+
+test("selectEvalTasks filters by task id and rejects missing tasks", () => {
+  const corpus = loadEvalCorpus(path.join("eval", "corpus"), REPO_ROOT);
+  const selected = selectEvalTasks(corpus, {
+    taskIds: ["factory-run-55-cost-telemetry-calibration"]
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].task_id, "factory-run-55-cost-telemetry-calibration");
+
+  assert.throws(
+    () => selectEvalTasks(corpus, { taskIds: ["does-not-exist"] }),
+    /Unknown eval task IDs/
+  );
+});
+
+test("parseEvalCliArgs supports task filters and output overrides", () => {
+  const parsed = parseEvalCliArgs([
+    "--task",
+    "a",
+    "--task",
+    "b",
+    "--split",
+    "dev",
+    "--output",
+    "eval/runs/manual-smoke"
+  ]);
+
+  assert.deepEqual(parsed, {
+    split: "dev",
+    taskIds: ["a", "b"],
+    output: "eval/runs/manual-smoke"
+  });
+});
+
+test("synthesizeTaskResult derives stage, review, cost, timing, and human audit fields", () => {
+  const repoRoot = makeTempRepoFixture();
+  const corpus = loadEvalCorpus(path.join("eval", "corpus"), repoRoot);
+  const task = selectEvalTasks(corpus)[0];
+  const result = synthesizeTaskResult({
+    task,
+    runId: "run-123",
+    corpusRevision: corpus.index.corpus_revision,
+    repoRoot,
+    evaluatedAt: "2026-04-06T00:15:00Z"
+  });
+
+  assert.equal(result.run_id, "run-123");
+  assert.equal(result.review_outcome.decision, "request_changes");
+  assert.equal(result.review_outcome.unmet_requirement_checks_count, 1);
+  assert.equal(result.stage_outcomes.plan.present, true);
+  assert.equal(result.stage_outcomes.implement.succeeded, true);
+  assert.equal(result.repair_summary.repair_log_present, true);
+  assert.equal(result.cost_summary.total_estimated_usd, 1.25);
+  assert.equal(result.cost_summary.has_actuals, true);
+  assert.equal(result.timing.started_at, "2026-04-06T00:00:00Z");
+  assert.equal(result.timing.duration_ms, 600000);
+  assert.equal(result.human_audit.required, true);
+  assert.equal(result.human_audit.status, "not_recorded");
+  assert.equal(result.intervention_summary.known, false);
+});
+
+test("summarizeEvalRun aggregates multiple task results", () => {
+  const taskResults = [
+    {
+      task_id: "a",
+      stage_outcomes: {
+        plan: { present: true, succeeded: true },
+        implement: { present: true, succeeded: true },
+        repair: { present: false, succeeded: false },
+        review: { present: true, succeeded: true }
+      },
+      review_outcome: { decision: "pass" },
+      intervention_summary: { known: false, count: null },
+      repair_summary: { present: false },
+      human_audit: { required: true, status: "not_recorded" },
+      cost_summary: { total_estimated_usd: 1, total_actual_usd: 0.5, has_actuals: true },
+      notes: ["a warning"]
+    },
+    {
+      task_id: "b",
+      stage_outcomes: {
+        plan: { present: true, succeeded: true },
+        implement: { present: true, succeeded: false },
+        repair: { present: true, succeeded: true },
+        review: { present: true, succeeded: true }
+      },
+      review_outcome: { decision: "request_changes" },
+      intervention_summary: { known: false, count: null },
+      repair_summary: { present: true },
+      human_audit: { required: false, status: "not_recorded" },
+      cost_summary: { total_estimated_usd: 2, total_actual_usd: 0, has_actuals: false },
+      notes: []
+    }
+  ];
+
+  const summary = summarizeEvalRun({
+    runId: "run-123",
+    corpusRevision: 1,
+    gitCommit: "abc123",
+    startedAt: "2026-04-06T00:00:00Z",
+    finishedAt: "2026-04-06T00:10:00Z",
+    taskResults,
+    selectedTaskIds: ["a", "b"]
+  });
+
+  assert.equal(summary.task_count, 2);
+  assert.equal(summary.stage_success_counts.plan.succeeded, 2);
+  assert.equal(summary.stage_success_counts.implement.succeeded, 1);
+  assert.equal(summary.review_decision_distribution.pass, 1);
+  assert.equal(summary.review_decision_distribution.request_changes, 1);
+  assert.equal(summary.repair_presence_rate, 0.5);
+  assert.equal(summary.cost_totals.total_estimated_usd, 3);
+  assert.equal(summary.cost_totals.tasks_with_actuals, 1);
+  assert.equal(summary.human_audit.missing_required_tasks, 1);
+  assert.match(summary.task_warnings[0], /a warning/);
+});
+
+test("runEval writes task results and aggregate outputs to the requested output directory", () => {
+  const repoRoot = makeTempRepoFixture();
+  const outputDir = path.join(repoRoot, "eval", "runs", "manual-smoke");
+
+  const result = runEval({
+    repoRoot,
+    output: outputDir,
+    now: () => new Date("2026-04-06T00:15:00Z"),
+    getGitCommitFn: () => "fixture-commit"
+  });
+
+  assert.equal(result.outputRoot, outputDir);
+  assert.equal(fileExists(path.join(outputDir, "run.json")), true);
+  assert.equal(fileExists(path.join(outputDir, "tasks", "task-1.json")), true);
+  assert.equal(fileExists(path.join(outputDir, "eval-summary.json")), true);
+  assert.equal(fileExists(path.join(outputDir, "eval-summary.md")), true);
+  assert.equal(result.summary.task_count, 1);
+});
+
+function fileExists(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem statement
The factory now has a private eval corpus, but it still lacks a reusable way to replay that corpus against the durable artifacts it already produces. Without a local eval substrate, changes to the factory are judged ad hoc from individual runs instead of through a repeatable corpus-level comparison.

## Motivation
Issue #91 is the first step in making factory improvement eval-driven. The goal here is to turn the repo-tracked corpus into a deterministic local replay harness that can summarize stage outcomes, review outcomes, repair evidence, cost signals, and missing-data warnings without triggering live workflows. That gives later work a stable base for requirement contracts, reviewer calibration, soft governance, and post-merge attribution.

## Reviewer context
This PR is intentionally scoped to artifact replay, not workflow execution.

Review with these constraints in mind:
- `scripts/eval.mjs` should only load the checked-in corpus, validate it, and run local replay.
- `scripts/lib/eval-runner.mjs` should synthesize normalized per-task results and aggregate summaries from existing `.factory/runs/*` and linked telemetry artifacts.
- The harness should emit explicit nulls or warnings when historical artifacts do not expose a signal rather than inventing data.
- `human_audit` is modeled now as placeholder schema only; this PR does not add real human-labeled judgments.
- `eval/runs/` is an output area only and should not accumulate checked-in run artifacts.

## Summary
- implement issue #91 as a local replay eval harness over the repo-tracked corpus
- add deterministic per-task and aggregate eval outputs under `eval/runs/`
- document the replay model and add CLI plus unit coverage

## What changed
- added `scripts/eval.mjs` as the eval entrypoint
- added `scripts/lib/eval-runner.mjs` for corpus loading, task synthesis, summaries, and output writing
- added `eval/runs/.gitignore` to reserve the generated output area without checking in runs
- added eval CLI and runner tests
- documented the eval substrate in `README.md`

## Notes
- this is local artifact replay, not live workflow execution or Codex re-runs
- the result schema models `human_audit` now, but leaves it unpopulated beyond placeholder status in this issue
- intervention state stays explicit when historical artifacts do not contain enough data to recover it

## Verification
- `node scripts/validate-eval-corpus.mjs`
- `node --test tests/eval-runner.test.mjs tests/eval-cli.test.mjs`
- `npm test`
- manual smoke: `node scripts/eval.mjs --task factory-run-55-cost-telemetry-calibration --output /tmp/issue-91-manual-smoke`

Closes #91
